### PR TITLE
Adds Justfile

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: Setup
+runs:
+  using: composite
+  steps:
+    - name: Setup Foundry
+    uses: foundry-rs/foundry-toolchain@v1
+    with:
+      version: nightly
+
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '^1.22'
+
+    - name: Setup Just
+      uses: extractions/setup-just@v1
+      with:
+        just-version: 1.5.0

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,9 +3,9 @@ runs:
   using: composite
   steps:
     - name: Setup Foundry
-    uses: foundry-rs/foundry-toolchain@v1
-    with:
-      version: nightly
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
 
     - name: Setup Go
       uses: actions/setup-go@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,13 @@ jobs:
   contracts-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup
-        uses: ./.github/actions/setup
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run Forge build
         run: |
@@ -44,11 +44,11 @@ jobs:
   go-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup
-        uses: ./.github/actions/setup
-
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,45 +23,35 @@ jobs:
   contracts-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup
+        uses: ./.github/actions/setup
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
       - name: Run Forge build
         run: |
-          forge --version
-          forge build --sizes --root ./contracts
+          just build-contracts
         id: build
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --root ./contracts
+          just test-contracts
         id: test
   
   go-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup
+        uses: ./.github/actions/setup
+
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.22'
 
       - name: Install dependencies
         run: go mod download
 
       - name: Run tests
-        run: go test ./... -v
+        run: just test-go

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,17 @@
+set positional-arguments
+
+build-contracts:
+    forge --version
+    forge build --sizes --root ./contracts
+
+build-go:
+    go build ./...
+
+test-contracts:
+    forge test -vvv --root ./contracts
+
+test-go:
+    go test ./... -v
+
+start:
+    go run ./...

--- a/scripts/local-dev-setup.sh
+++ b/scripts/local-dev-setup.sh
@@ -13,9 +13,7 @@ if ! command -v just > /dev/null 2>&1; then
     # download and extract just to ~/bin/just
     curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin
 
-    # add `~/bin` to the paths that your shell searches for executables
-    # this line should be added to your shells initialization file,
-    # e.g. `~/.bashrc` or `~/.zshrc`
+    # add `~/bin` to your path
     export PATH="$PATH:$HOME/bin"
 
     echo "just has been installed"

--- a/scripts/local-dev-setup.sh
+++ b/scripts/local-dev-setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+##################
+#   Just Setup   #
+##################
+
+echo "Checking just setup"
+
+if ! command -v just > /dev/null 2>&1; then
+    # create ~/bin
+    mkdir -p ~/bin
+
+    # download and extract just to ~/bin/just
+    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/bin
+
+    # add `~/bin` to the paths that your shell searches for executables
+    # this line should be added to your shells initialization file,
+    # e.g. `~/.bashrc` or `~/.zshrc`
+    export PATH="$PATH:$HOME/bin"
+
+    echo "just has been installed"
+else
+    echo "skipping just install, it already exists."
+fi


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds `Justfile` along with some commands
  * `build-contracts` builds the forge project
  * `build-go` builds supersim
  * `test-contracts` runs the forge unit tests
  * `test-go` runs the go unit tests
  * `start` starts supersim
* Adds `scripts/local-dev-setup.sh` this is the start of a script we can use to make it easy for devs to setup their local dev environment
* Updates our github actions to install `just` and updates the commands in the actions to use the `Justfile`

Once we merge this in will follow on with some README updates!