### PR TITLE
feat(genesis-state): embed genesis state files in go binary

### DIFF
--- a/supersim.go
+++ b/supersim.go
@@ -1,6 +1,7 @@
 package supersim
 
 import (
+	_ "embed"
 	"fmt"
 
 	"context"
@@ -15,11 +16,17 @@ type Config struct {
 	l2Chains []anvil.Config
 }
 
+//go:embed genesis/genesis-l1.json
+var genesisL1JSON []byte
+
+//go:embed genesis/genesis-l2.json
+var genesisL2JSON []byte
+
 var DefaultConfig = Config{
-	l1Chain: anvil.Config{ChainId: 1, Port: 8545, GenesisPath: "genesis/genesis-l1.json"},
+	l1Chain: anvil.Config{ChainId: 1, Port: 8545, Genesis: genesisL1JSON},
 	l2Chains: []anvil.Config{
-		{ChainId: 10, Port: 9545, GenesisPath: "genesis/genesis-l2.json"},
-		{ChainId: 30, Port: 9555, GenesisPath: "genesis/genesis-l2.json"},
+		{ChainId: 10, Port: 9545, Genesis: genesisL2JSON},
+		{ChainId: 30, Port: 9555, Genesis: genesisL2JSON},
 	},
 }
 

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/supersim/testutils"
+	"github.com/ethereum-optimism/supersim/utils"
 )
 
 const (
@@ -27,7 +27,7 @@ func TestGenesisState(t *testing.T) {
 	defer supersim.Stop(context.Background())
 
 	for _, l2ChainConfig := range DefaultConfig.l2Chains {
-		client, err := testutils.WaitForAnvilClientToBeReady(fmt.Sprintf("http://127.0.0.1:%d", l2ChainConfig.Port), anvilClientTimeout)
+		client, err := utils.WaitForAnvilClientToBeReady(fmt.Sprintf("http://127.0.0.1:%d", l2ChainConfig.Port), anvilClientTimeout)
 		if err != nil {
 			t.Fatalf("Failed to connect to RPC server: %v", err)
 		}

--- a/utils/rpc.go
+++ b/utils/rpc.go
@@ -1,8 +1,9 @@
-package testutils
+package utils
 
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
@@ -20,9 +21,16 @@ func WaitForAnvilClientToBeReady(rpcUrl string, timeout time.Duration) (*rpc.Cli
 		case <-ctx.Done():
 			return nil, fmt.Errorf("timed out waiting for response from %s", rpcUrl)
 		case <-ticker.C:
-			client, err := rpc.Dial(rpcUrl)
+			_, err := http.Get(rpcUrl)
+
 			if err != nil {
 				fmt.Printf("Error making request: %v\n", err)
+				continue
+			}
+
+			client, err := rpc.Dial(rpcUrl)
+			if err != nil {
+				fmt.Printf("Error creating rpc client: %v\n", err)
 				continue
 			}
 


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/supersim/issues/15

Realized that the genesis files need to be embedded into the go executable. This PR embeds the genesis json files, writes them to a temporary file, and then passes the temp file into the anvil instances on startup. 