### PR TITLE
Adds Go Linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,26 @@ jobs:
           just test-contracts
         id: test
   
+  go-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Setup golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run linter
+        run: just lint-go
+
   go-tests:
     runs-on: ubuntu-latest
     steps:

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,9 @@ build-contracts:
 build-go:
     go build ./...
 
+lint-go:
+    golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+
 test-contracts:
     forge test -vvv --root ./contracts
 

--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -58,13 +58,13 @@ func (a *Anvil) Start(ctx context.Context) error {
 
 	tempFile, err := os.CreateTemp("", "genesis-*.json")
 	if err != nil {
-		return fmt.Errorf("Error creating temporary genesis file: %v", err)
+		return fmt.Errorf("Error creating temporary genesis file: %w", err)
 	}
 	defer os.Remove(tempFile.Name())
 
 	_, err = tempFile.Write(a.cfg.Genesis)
 	if err != nil {
-		return fmt.Errorf("Error writing to genesis file: %v", err)
+		return fmt.Errorf("Error writing to genesis file: %w", err)
 	}
 
 	// Prep args
@@ -72,7 +72,7 @@ func (a *Anvil) Start(ctx context.Context) error {
 		"--host", host,
 		"--chain-id", fmt.Sprintf("%d", a.cfg.ChainId),
 		"--port", fmt.Sprintf("%d", a.cfg.Port),
-		"--init", fmt.Sprintf("%s", tempFile.Name()),
+		"--init", tempFile.Name(),
 	}
 
 	a.cmd = exec.CommandContext(a.resourceCtx, "anvil", args...)

--- a/scripts/local-dev-setup.sh
+++ b/scripts/local-dev-setup.sh
@@ -20,3 +20,16 @@ if ! command -v just > /dev/null 2>&1; then
 else
     echo "skipping just install, it already exists."
 fi
+
+##################
+#   Go Setup   #
+##################
+
+echo "Checking go setup"
+
+if ! command -v golangci-lint > /dev/null 2>&1; then
+    # binary will be $(go env GOPATH)/bin/golangci-lint
+    echo "Instaling golangci-lint"
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
+    golangci-lint --version
+fi

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -23,8 +23,14 @@ const (
 func TestGenesisState(t *testing.T) {
 	logger := oplog.NewLogger(os.Stderr, oplog.DefaultCLIConfig())
 	supersim := NewSupersim(logger, &DefaultConfig)
-	supersim.Start(context.Background())
-	defer supersim.Stop(context.Background())
+	_ = supersim.Start(context.Background())
+
+	defer func() {
+		err := supersim.Stop(context.Background())
+		if err != nil {
+			t.Fatalf("Failed to stop supersim: %v", err)
+		}
+	}()
 
 	for _, l2ChainConfig := range DefaultConfig.l2Chains {
 		client, err := utils.WaitForAnvilClientToBeReady(fmt.Sprintf("http://127.0.0.1:%d", l2ChainConfig.Port), anvilClientTimeout)

--- a/utils/rpc.go
+++ b/utils/rpc.go
@@ -21,12 +21,13 @@ func WaitForAnvilClientToBeReady(rpcUrl string, timeout time.Duration) (*rpc.Cli
 		case <-ctx.Done():
 			return nil, fmt.Errorf("timed out waiting for response from %s", rpcUrl)
 		case <-ticker.C:
-			_, err := http.Get(rpcUrl)
+			res, err := http.Get(rpcUrl)
 
 			if err != nil {
 				fmt.Printf("Error making request: %v\n", err)
 				continue
 			}
+			defer res.Body.Close()
 
 			client, err := rpc.Dial(rpcUrl)
 			if err != nil {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds [golangci-lint](https://golangci-lint.run/), this is what we're using in the monorepo.
* Updates `local-dev-setup.sh` to include an install step for the linter to be used locally
* Updates `Justfile` to include a new command called `lint-go`. The command used here is shamelessly copied from the monorepo. I figure it's best to start with the same linting rules and adjust from here.
* Updates CI to run the linter
* Fixes lint issues
