### PR TITLE
feat: starting with port 0

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -60,7 +60,7 @@ func (a *Anvil) Start(ctx context.Context) error {
 	}
 
 	args := []string{
-		//"--silent",
+		"--silent",
 		"--host", host,
 		"--chain-id", fmt.Sprintf("%d", a.cfg.ChainId),
 		"--port", fmt.Sprintf("%d", a.cfg.Port),

--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -60,7 +60,6 @@ func (a *Anvil) Start(ctx context.Context) error {
 	}
 
 	args := []string{
-		"--silent",
 		"--host", host,
 		"--chain-id", fmt.Sprintf("%d", a.cfg.ChainId),
 		"--port", fmt.Sprintf("%d", a.cfg.Port),

--- a/anvil/anvil_test.go
+++ b/anvil/anvil_test.go
@@ -19,7 +19,7 @@ func TestAnvil(t *testing.T) {
 
 	require.NoError(t, anvil.Start(context.Background()))
 
-	// port overriden on startup
+	// port overridden on startup
 	require.NotEqual(t, cfg.Port, 0)
 
 	client, err := rpc.Dial(anvil.Endpoint())

--- a/anvil/anvil_test.go
+++ b/anvil/anvil_test.go
@@ -1,0 +1,32 @@
+package anvil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func TestAnvil(t *testing.T) {
+	cfg := Config{ChainId: 10, Port: 0}
+	testlog := testlog.Logger(t, log.LevelInfo)
+	anvil := New(testlog, &cfg)
+
+	require.NoError(t, anvil.Start(context.Background()))
+
+	// port overriden on startup
+	require.NotEqual(t, cfg.Port, 0)
+
+	client, err := rpc.Dial(anvil.Endpoint())
+	require.NoError(t, err)
+
+	// query chainId
+	var chainId math.HexOrDecimal64
+	require.NoError(t, client.CallContext(context.Background(), &chainId, "eth_chainId"))
+	require.Equal(t, uint64(chainId), cfg.ChainId)
+}

--- a/supersim.go
+++ b/supersim.go
@@ -32,17 +32,17 @@ var genesisL2JSON []byte
 
 var DefaultConfig = Config{
 	l1Chain: ChainConfig{
-		anvilConfig: anvil.Config{ChainId: 1, Port: 8545, Genesis: genesisL1JSON},
-		opSimConfig: opsim.Config{Port: 8546},
+		anvilConfig: anvil.Config{ChainId: 1, Port: 0, Genesis: genesisL1JSON},
+		opSimConfig: opsim.Config{Port: 0},
 	},
 	l2Chains: []ChainConfig{
 		{
-			anvilConfig: anvil.Config{ChainId: 10, Port: 9545, Genesis: genesisL2JSON},
-			opSimConfig: opsim.Config{Port: 9546},
+			anvilConfig: anvil.Config{ChainId: 10, Port: 0, Genesis: genesisL2JSON},
+			opSimConfig: opsim.Config{Port: 0},
 		},
 		{
-			anvilConfig: anvil.Config{ChainId: 30, Port: 9555, Genesis: genesisL2JSON},
-			opSimConfig: opsim.Config{Port: 9556},
+			anvilConfig: anvil.Config{ChainId: 30, Port: 0, Genesis: genesisL2JSON},
+			opSimConfig: opsim.Config{Port: 0},
 		},
 	},
 }

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -30,7 +30,6 @@ type TestSuite struct {
 
 func createTestSuite(t *testing.T) *TestSuite {
 	cfg := &DefaultConfig
-
 	testlog := testlog.Logger(t, log.LevelInfo)
 	supersim := NewSupersim(testlog, cfg)
 	t.Cleanup(func() {


### PR DESCRIPTION
We dont want to have to specify both the anvil & simulator ports when the anvil port is an implementation detail.

In order to simplify config, we provide the ability to start anvil on port `0`, meaning whatever is available on the host. This way we don't need to predefine this port. Since anvil is an external process, we extract the port by waiting for the `Listening on` log emitted when starting anvil.


## Fixes
Only apply the genesis arg to anvil if present in the config