### PR TITLE
feat: interop invariant checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ Supersim allows developers to start multiple local evm nodes with one command, a
 Supersim is a lightweight tool that simulates an interoperable Superchain environment locally. It does not require a complicated devnet setup and is run using cli commands with configuration options that fall back to sensible defaults if they are not specified. Each chain is an instance of [anvil](https://book.getfoundry.sh/reference/anvil/), though future versions may support other local testing tools.
 
 ## Getting started
-### Installation
-TODO
+### Running Locally
+1. build the binary by running:
+```
+go build cmd/main.go
+```
+2. start supersim in vanilla mode by running:
+```
+./main
+```
 
 ## Features
 ### Vanilla mode

--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"os/exec"
 	"strconv"
@@ -283,7 +284,24 @@ func (a *Anvil) EthSendTransaction(ctx context.Context, tx *types.Transaction) e
 	return a.ethClient.SendTransaction(ctx, tx)
 }
 
+func (a *Anvil) EthBlockByNumber(ctx context.Context, blockHeight *big.Int) (*types.Block, error) {
+	return a.ethClient.BlockByNumber(ctx, blockHeight)
+}
+
 // subscription API
 func (a *Anvil) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	return a.ethClient.SubscribeFilterLogs(ctx, q, ch)
+}
+
+func (a *Anvil) DebugTraceCall(ctx context.Context, txArgs config.TransactionArgs) (config.TraceCallRaw, error) {
+	var result config.TraceCallRaw
+	if err := a.rpcClient.CallContext(ctx, &result, "debug_traceCall", txArgs, "latest", map[string]interface{}{
+		"tracer": "callTracer",
+		"tracerConfig": map[string]interface{}{
+			"withLog": true,
+		},
+	}); err != nil {
+		return config.TraceCallRaw{}, err
+	}
+	return result, nil
 }

--- a/config/chain.go
+++ b/config/chain.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"strings"
 
 	registry "github.com/ethereum-optimism/superchain-registry/superchain"
@@ -12,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -96,6 +98,35 @@ type NetworkConfig struct {
 	L2Configs      []ChainConfig
 }
 
+type TransactionArgs struct {
+	From     common.Address  `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      hexutil.Uint64  `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Data     hexutil.Bytes   `json:"data"`
+	Value    *hexutil.Big    `json:"value"`
+}
+
+type TraceCallRaw struct {
+	Error   *string            `json:"error,omitempty"`
+	Type    string             `json:"type"`
+	From    string             `json:"from"`
+	To      string             `json:"to"`
+	Value   string             `json:"value"`
+	Gas     string             `json:"gas"`
+	GasUsed string             `json:"gasUsed"`
+	Input   string             `json:"input"`
+	Output  string             `json:"output"`
+	Logs    []*TraceCallRawLog `json:"logs"`
+	Calls   []TraceCallRaw     `json:"calls"`
+}
+
+type TraceCallRawLog struct {
+	Address common.Address `json:"address"`
+	Topics  []common.Hash  `json:"topics"`
+	Data    string         `json:"data"`
+}
+
 type Chain interface {
 	Name() string
 	Endpoint() string
@@ -109,7 +140,10 @@ type Chain interface {
 	EthGetCode(ctx context.Context, account common.Address) ([]byte, error)
 	EthGetLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 	EthSendTransaction(ctx context.Context, tx *types.Transaction) error
+	EthBlockByNumber(ctx context.Context, blockHeight *big.Int) (*types.Block, error)
+
 	SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
+	DebugTraceCall(ctx context.Context, txArgs TransactionArgs) (TraceCallRaw, error)
 }
 
 // Note: The default secrets config is used everywhere

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -5,6 +5,8 @@ out/
 # Ignores development broadcast logs
 !/broadcast
 /broadcast/*/31337/
+/broadcast/*/901/
+/broadcast/*/902/
 /broadcast/**/dry-run/
 
 # Docs

--- a/opsimulator/crossl2inbox.go
+++ b/opsimulator/crossl2inbox.go
@@ -1,0 +1,73 @@
+package opsimulator
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	eventExecutingMessage = "ExecutingMessage"
+)
+
+var (
+	ErrEventNotFound = errors.New("event not found")
+)
+
+type executingMessage struct {
+	MsgHash    [32]byte
+	Identifier MessageIdentifier
+}
+
+type MessageIdentifier struct {
+	Origin      common.Address
+	BlockNumber *big.Int
+	LogIndex    *big.Int
+	Timestamp   *big.Int
+	ChainId     *big.Int
+}
+
+type crossL2Inbox struct {
+	Contract *batching.BoundContract
+	Abi      abi.ABI
+}
+
+func NewCrossL2Inbox() *crossL2Inbox {
+	abi := snapshots.LoadCrossL2InboxABI()
+	return &crossL2Inbox{
+		Abi:      *abi,
+		Contract: batching.NewBoundContract(abi, predeploys.CrossL2InboxAddr),
+	}
+}
+
+func (i *crossL2Inbox) decodeExecutingMessageLog(l *types.Log) (*executingMessage, error) {
+	if l.Address != i.Contract.Addr() {
+		return nil, nil
+	}
+	name, result, err := i.Contract.DecodeEvent(l)
+	if errors.Is(err, batching.ErrUnknownEvent) {
+		return nil, fmt.Errorf("%w: %v", ErrEventNotFound, err.Error())
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to decode event: %w", err)
+	}
+	if name != eventExecutingMessage {
+		return nil, nil
+	}
+
+	msgHash := result.GetBytes32(0)
+	var messageIdentifier MessageIdentifier
+	result.GetStruct(1, &messageIdentifier)
+
+	return &executingMessage{
+		MsgHash:    msgHash,
+		Identifier: messageIdentifier,
+	}, nil
+}

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -36,7 +36,7 @@ func NewOrchestrator(log log.Logger, networkConfig *config.NetworkConfig) (*Orch
 
 		l2Anvil := anvil.New(log, &cfg)
 		l2Anvils[cfg.ChainID] = l2Anvil
-		L2OpSims[cfg.ChainID] = opsimulator.New(log, nextL2Port, l1Anvil, l2Anvil, cfg.L2Config)
+		L2OpSims[cfg.ChainID] = opsimulator.New(log, nextL2Port, l1Anvil, l2Anvil, cfg.L2Config, l2Anvils)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum-optimism/supersim/config"
 
@@ -64,6 +65,14 @@ func (c *MockChain) EthSendTransaction(ctx context.Context, tx *types.Transactio
 	return nil
 }
 
+func (c *MockChain) EthBlockByNumber(ctx context.Context, blockHeight *big.Int) (*types.Block, error) {
+	return &types.Block{}, nil
+}
+
 func (c *MockChain) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	return &MockSubscription{}, nil
+}
+
+func (c *MockChain) DebugTraceCall(ctx context.Context, txArgs config.TransactionArgs) (config.TraceCallRaw, error) {
+	return config.TraceCallRaw{}, nil
 }


### PR DESCRIPTION
Closes: https://github.com/ethereum-optimism/supersim/issues/19
Closes: https://github.com/ethereum-optimism/supersim/issues/18

Adds interop invariant checks to the opsimulator, and will reject transactions that do not meet the interop invariants. The interop invariant checks are in line with the interop spec: https://specs.optimism.io/interop/overview.html