### PR TITLE
feat(opsim): listen for deposit transactions

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -71,6 +71,7 @@ func (a *Anvil) Start(ctx context.Context) error {
 		"--derivation-path", a.cfg.SecretsConfig.DerivationPath.String(),
 		"--chain-id", fmt.Sprintf("%d", a.cfg.ChainID),
 		"--port", fmt.Sprintf("%d", a.cfg.Port),
+		"--optimism",
 	}
 
 	if len(a.cfg.GenesisJSON) > 0 && a.cfg.ForkConfig == nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,7 @@ var (
 )
 
 const (
-	minAnvilTimestamp = "2024-07-12T00:22:06.921038000Z"
+	minAnvilTimestamp = "2024-07-25T15:52:50.932621000Z"
 )
 
 func main() {

--- a/hdaccount/hd_account_store.go
+++ b/hdaccount/hd_account_store.go
@@ -42,7 +42,7 @@ func NewHdAccountStore(mnemonic string, basePath accounts.DerivationPath) (*HdAc
 	return &HdAccountStore{mnemonic: mnemonic, basePath: basePath, seed: seed, masterKey: masterKey}, nil
 }
 
-func (h *HdAccountStore) derivePrivateKeyAt(index uint32) (*ecdsa.PrivateKey, error) {
+func (h *HdAccountStore) DerivePrivateKeyAt(index uint32) (*ecdsa.PrivateKey, error) {
 
 	var key *hdkeychain.ExtendedKey
 	key = h.masterKey
@@ -65,8 +65,8 @@ func (h *HdAccountStore) derivePrivateKeyAt(index uint32) (*ecdsa.PrivateKey, er
 	return privateKeyECDSA, nil
 }
 
-func (h *HdAccountStore) derivePublicKeyAt(index uint32) (*ecdsa.PublicKey, error) {
-	privateKeyECDSA, err := h.derivePrivateKeyAt(index)
+func (h *HdAccountStore) DerivePublicKeyAt(index uint32) (*ecdsa.PublicKey, error) {
+	privateKeyECDSA, err := h.DerivePrivateKeyAt(index)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (h *HdAccountStore) derivePublicKeyAt(index uint32) (*ecdsa.PublicKey, erro
 }
 
 func (h *HdAccountStore) PrivateKeyHexAt(index uint32) (string, error) {
-	privateKey, err := h.derivePrivateKeyAt(index)
+	privateKey, err := h.DerivePrivateKeyAt(index)
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +90,7 @@ func (h *HdAccountStore) PrivateKeyHexAt(index uint32) (string, error) {
 }
 
 func (h *HdAccountStore) AddressHexAt(index uint32) (string, error) {
-	publicKey, err := h.derivePublicKeyAt(index)
+	publicKey, err := h.DerivePublicKeyAt(index)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/supersim/issues/26

- opsim on startup starts a background task to listen for L1 deposit transactions
- simply takes a emitted deposit tx log and submits it as a Deposit transaction type on the L2
- NOTE: test will fail this needs to wait until the new foundry nightly build gets released with the fix for block.basefee override. won't merge until Jul 26th