### PR TITLE
Port Configuration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,15 +43,17 @@ func main() {
 	app.Description = "Local multichain optimism development environment"
 	app.Action = cliapp.LifecycleCmd(SupersimMain)
 
+	baseFlags := append(config.BaseCLIFlags(EnvVarPrefix), logFlags...)
+
 	// Vanilla mode has no specific flags for now
-	app.Flags = logFlags
+	app.Flags = baseFlags
 
 	// Subcommands
 	app.Commands = []*cli.Command{
 		{
 			Name:   config.ForkCommandName,
 			Usage:  "Locally fork a network in the superchain registry",
-			Flags:  append(config.ForkCLIFlags(EnvVarPrefix), logFlags...),
+			Flags:  append(config.ForkCLIFlags(EnvVarPrefix), baseFlags...),
 			Action: cliapp.LifecycleCmd(SupersimMain),
 		},
 	}

--- a/config/chain.go
+++ b/config/chain.go
@@ -22,31 +22,33 @@ var (
 		DerivationPath: accounts.DefaultRootDerivationPath,
 	}
 
-	DefaultChainConfigs = []ChainConfig{
-		{
-			Name:          "SourceChain",
+	DefaultNetworkConfig = NetworkConfig{
+		L1Config: ChainConfig{
+			Name:          "L1",
 			ChainID:       genesis.GeneratedGenesisDeployment.L1.ChainID,
 			SecretsConfig: DefaultSecretsConfig,
 			GenesisJSON:   genesis.GeneratedGenesisDeployment.L1.GenesisJSON,
 		},
-		{
-			Name:          "OPChainA",
-			ChainID:       genesis.GeneratedGenesisDeployment.L2s[0].ChainID,
-			SecretsConfig: DefaultSecretsConfig,
-			GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[0].GenesisJSON,
-			L2Config: &L2Config{
-				L1ChainID:   genesis.GeneratedGenesisDeployment.L1.ChainID,
-				L1Addresses: genesis.GeneratedGenesisDeployment.L2s[0].RegistryAddressList(),
+		L2Configs: []ChainConfig{
+			{
+				Name:          "OPChainA",
+				ChainID:       genesis.GeneratedGenesisDeployment.L2s[0].ChainID,
+				SecretsConfig: DefaultSecretsConfig,
+				GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[0].GenesisJSON,
+				L2Config: &L2Config{
+					L1ChainID:   genesis.GeneratedGenesisDeployment.L1.ChainID,
+					L1Addresses: genesis.GeneratedGenesisDeployment.L2s[0].RegistryAddressList(),
+				},
 			},
-		},
-		{
-			Name:          "OPChainB",
-			ChainID:       genesis.GeneratedGenesisDeployment.L2s[1].ChainID,
-			SecretsConfig: DefaultSecretsConfig,
-			GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[1].GenesisJSON,
-			L2Config: &L2Config{
-				L1ChainID:   genesis.GeneratedGenesisDeployment.L1.ChainID,
-				L1Addresses: genesis.GeneratedGenesisDeployment.L2s[1].RegistryAddressList(),
+			{
+				Name:          "OPChainB",
+				ChainID:       genesis.GeneratedGenesisDeployment.L2s[1].ChainID,
+				SecretsConfig: DefaultSecretsConfig,
+				GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[1].GenesisJSON,
+				L2Config: &L2Config{
+					L1ChainID:   genesis.GeneratedGenesisDeployment.L1.ChainID,
+					L1Addresses: genesis.GeneratedGenesisDeployment.L2s[1].RegistryAddressList(),
+				},
 			},
 		},
 	}
@@ -69,21 +71,25 @@ type L2Config struct {
 }
 
 type ChainConfig struct {
-	Name string
-	Port uint64
-
+	Name    string
+	Port    uint64
 	ChainID uint64
 
-	GenesisJSON []byte
-
+	GenesisJSON   []byte
 	SecretsConfig SecretsConfig
 
 	// Optional Config
 	ForkConfig *ForkConfig
 
-	// Optional Config
-	// Chain is an L1 chain if L2Config is nil
+	// Optional Config (L1 chain if nil)
 	L2Config *L2Config
+}
+
+type NetworkConfig struct {
+	L1Config ChainConfig
+
+	L2StartingPort uint64
+	L2Configs      []ChainConfig
 }
 
 type Chain interface {
@@ -91,6 +97,7 @@ type Chain interface {
 	Endpoint() string
 	ChainID() uint64
 	LogPath() string
+	Config() *ChainConfig
 
 	// API methods
 	EthGetCode(ctx context.Context, account common.Address) ([]byte, error)

--- a/config/cli.go
+++ b/config/cli.go
@@ -34,7 +34,7 @@ func BaseCLIFlags(envPrefix string) []cli.Flag {
 			Name:    L2StartingPortFlagName,
 			Usage:   "Starting port to increment from for L2 chains. `0` binds each chain to any available port",
 			Value:   9545,
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "L1_PORT"),
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "L2_STARTING_PORT"),
 		},
 	}
 }

--- a/config/cli.go
+++ b/config/cli.go
@@ -15,9 +15,29 @@ const (
 	ForkCommandName = "fork"
 
 	L1ForkHeightFlagName = "l1.fork.height"
-	ChainsFlagName       = "chains"
-	NetworkFlagName      = "network"
+	L1PortFlagName       = "l1.port"
+
+	ChainsFlagName         = "chains"
+	NetworkFlagName        = "network"
+	L2StartingPortFlagName = "l2.starting.port"
 )
+
+func BaseCLIFlags(envPrefix string) []cli.Flag {
+	return []cli.Flag{
+		&cli.Uint64Flag{
+			Name:    L1PortFlagName,
+			Usage:   "Listening port for the L1 instance. `0` binds to any available port",
+			Value:   8545,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "L1_PORT"),
+		},
+		&cli.Uint64Flag{
+			Name:    L2StartingPortFlagName,
+			Usage:   "Starting port to increment from for L2 chains. `0` binds each chain to any available port",
+			Value:   9545,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "L1_PORT"),
+		},
+	}
+}
 
 func ForkCLIFlags(envPrefix string) []cli.Flag {
 	networks := strings.Join(superchainNetworks(), ", ")
@@ -51,11 +71,18 @@ type ForkCLIConfig struct {
 }
 
 type CLIConfig struct {
+	L1Port         uint64
+	L2StartingPort uint64
+
 	ForkConfig *ForkCLIConfig
 }
 
 func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
-	cfg := &CLIConfig{}
+	cfg := &CLIConfig{
+		L1Port:         ctx.Uint64(L1PortFlagName),
+		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
+	}
+
 	if ctx.Command.Name == ForkCommandName {
 		cfg.ForkConfig = &ForkCLIConfig{
 			L1ForkHeight: ctx.Uint64(L1ForkHeightFlagName),

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -34,7 +34,7 @@ type OpSimulator struct {
 	l1Chain config.Chain
 	l2Chain config.Chain
 
-	L2Config *config.L2Config
+	l2Config *config.L2Config
 
 	bgTasks       tasks.Group
 	bgTasksCtx    context.Context
@@ -53,20 +53,19 @@ type JSONRPCRequest struct {
 	JSONRPC string        `json:"jsonrpc"`
 }
 
-func New(log log.Logger, port uint64, l1Chain config.Chain, l2Chain config.Chain, l2Config *config.L2Config) *OpSimulator {
+func New(log log.Logger, port uint64, l1Chain, l2Chain config.Chain, l2Config *config.L2Config) *OpSimulator {
 	bgTasksCtx, bgTasksCancel := context.WithCancel(context.Background())
-
 	return &OpSimulator{
 		port:          port,
 		log:           log,
 		l1Chain:       l1Chain,
 		l2Chain:       l2Chain,
-		L2Config:      l2Config,
+		l2Config:      l2Config,
 		bgTasksCancel: bgTasksCancel,
 		bgTasksCtx:    bgTasksCtx,
 		bgTasks: tasks.Group{
 			HandleCrit: func(err error) {
-				log.Error("bg task failed", err)
+				log.Error("bg task failed", "err", err)
 			},
 		},
 	}
@@ -90,19 +89,16 @@ func (opSim *OpSimulator) Start(ctx context.Context) error {
 	opSim.httpServer = hs
 
 	if opSim.port == 0 {
-		port, err := strconv.ParseInt(strings.Split(hs.Addr().String(), ":")[1], 10, 64)
+		opSim.port, err = strconv.ParseUint(strings.Split(hs.Addr().String(), ":")[1], 10, 64)
 		if err != nil {
 			panic(fmt.Errorf("unexpected opsimulator listening port: %w", err))
 		}
-
-		opSim.port = uint64(port)
 	}
 
-	// Relay deposit tx from L1 to L2
+	// Relay deposit txs from L1 to L2
 	opSim.bgTasks.Go(func() error {
 		depositTxCh := make(chan *types.DepositTx)
-		sub, err := SubscribeDepositTx(context.Background(), opSim.l1Chain, common.Address(opSim.L2Config.L1Addresses.OptimismPortalProxy), depositTxCh)
-
+		sub, err := SubscribeDepositTx(context.Background(), opSim.l1Chain, common.Address(opSim.l2Config.L1Addresses.OptimismPortalProxy), depositTxCh)
 		if err != nil {
 			return fmt.Errorf("failed to subscribe to deposit tx: %w", err)
 		}
@@ -110,16 +106,13 @@ func (opSim *OpSimulator) Start(ctx context.Context) error {
 		for {
 			select {
 			case dep := <-depositTxCh:
-
 				depTx := types.NewTx(dep)
-
-				opSim.log.Debug("received deposit tx with hash:", depTx.Hash().Hex())
-
+				opSim.log.Debug("received deposit tx", "hash", depTx.Hash().String())
 				if err := opSim.l2Chain.EthSendTransaction(opSim.bgTasksCtx, depTx); err != nil {
 					opSim.log.Error("failed to submit deposit tx: %w", err)
 				}
 
-				opSim.log.Debug("submitted deposit tx with hash:", depTx.Hash().Hex())
+				opSim.log.Debug("submitted deposit tx", "hash", depTx.Hash().String())
 
 			case <-opSim.bgTasksCtx.Done():
 				sub.Unsubscribe()
@@ -206,8 +199,8 @@ func (opSim *OpSimulator) ChainID() uint64 {
 	return opSim.l2Chain.ChainID()
 }
 
-func (opSim *OpSimulator) SourceChainID() uint64 {
-	return opSim.L2Config.L1ChainID
+func (opSim *OpSimulator) Config() *config.ChainConfig {
+	return opSim.l2Chain.Config()
 }
 
 func (opSim *OpSimulator) String() string {

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -43,6 +43,10 @@ func (c *MockChain) LogPath() string {
 	return "var/chain/log"
 }
 
+func (c *MockChain) Config() *config.ChainConfig {
+	return nil
+}
+
 func (c *MockChain) EthGetCode(ctx context.Context, account common.Address) ([]byte, error) {
 	return []byte{}, nil
 }


### PR DESCRIPTION
Closes ethereum-optimism/supersim#68

Binding to port `0` is useful in scenarios like CI where port conflicts are likely. The default behavior of supersim should be predictable. We add two cli flags
```
    --l1.port value                     (default: 8545)                    ($SUPERSIM_L1_PORT)
          Listening port for the L1 instance. `0` binds to any available port

    --l2.starting.port value            (default: 9545)                    ($SUPERSIM_L2_STARTING_PORT)
          Starting port to increment from for L2 chains. `0` binds each chain to any
          available port
```

**Related changes**
1. Anvil.Start() must always wait for the port to be available. Otherwise the rpc can't establish a connection. We can remove `WaitUntilReady` for anvil because of this (separate pr)
2. Some code cleanup on `SourceChainID`. Since `L2Config` is apart of the chain configuration, `L2Config == nil` is a better indicator if a chain is L1/L2
3. Explicit `NetworkConfig` cleans up some startup code as well