### PR TITLE
Update reverse proxy to handle options requests

### DIFF
--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -180,6 +180,15 @@ func (opSim *OpSimulator) startBackgroundTasks() {
 
 func handler(proxy *httputil.ReverseProxy) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			// handle preflight requests
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "*")
+			w.Header().Set("Access-Control-Allow-Headers", "*")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "Failed to read request body", http.StatusInternalServerError)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates the reverse proxy to return a `204` along with the cors headers, when the browser triggers a preflight request