### PR TITLE
fix: opsimulator json parsing logic / feat: parse batch requests

### DIFF
--- a/opsimulator/json.go
+++ b/opsimulator/json.go
@@ -1,0 +1,47 @@
+package opsimulator
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// some parts copied over from op-geth as these are private
+
+type jsonRpcMessage struct {
+	Version string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+
+	// Since we're just proxying back the response,
+	// no need to include the Error/Result fields
+}
+
+func readJsonMessages(body io.Reader) ([]*jsonRpcMessage, error) {
+	var rawmsg json.RawMessage
+	if err := json.NewDecoder(body).Decode(&rawmsg); err != nil {
+		return nil, err
+	}
+
+	if !isJsonRpcBatch(rawmsg) {
+		msgs := []*jsonRpcMessage{{}}
+		err := json.Unmarshal(rawmsg, &msgs[0])
+		return msgs, err
+	}
+
+	var msgs []*jsonRpcMessage
+	err := json.Unmarshal(rawmsg, &msgs)
+	return msgs, err
+}
+
+// isBatch returns true when the first non-whitespace characters is '['
+func isJsonRpcBatch(raw json.RawMessage) bool {
+	for _, c := range raw {
+		// skip insignificant whitespace (http://www.ietf.org/rfc/rfc4627.txt)
+		if c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d {
+			continue
+		}
+		return c == '['
+	}
+	return false
+}

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -19,16 +19,9 @@ type TestSuite struct {
 }
 
 func createTestSuite(t *testing.T) *TestSuite {
-	networkConfig := config.NetworkConfig{
-		L1Config: config.ChainConfig{ChainID: 1, Port: 0},
-		L2Configs: []config.ChainConfig{
-			{ChainID: 10, Port: 0, L2Config: &config.L2Config{L1ChainID: 1}},
-			{ChainID: 30, Port: 0, L2Config: &config.L2Config{L1ChainID: 1}},
-		},
-	}
-
+	networkConfig := &config.DefaultNetworkConfig
 	testlog := testlog.Logger(t, log.LevelInfo)
-	orchestrator, _ := NewOrchestrator(testlog, &networkConfig)
+	orchestrator, _ := NewOrchestrator(testlog, networkConfig)
 	t.Cleanup(func() {
 		if err := orchestrator.Stop(context.Background()); err != nil {
 			t.Errorf("failed to stop orchestrator: %s", err)
@@ -46,17 +39,17 @@ func createTestSuite(t *testing.T) *TestSuite {
 func TestStartup(t *testing.T) {
 	testSuite := createTestSuite(t)
 
-	require.Equal(t, testSuite.orchestrator.L1Chain().ChainID(), uint64(1))
+	require.Equal(t, testSuite.orchestrator.L1Chain().ChainID(), uint64(900))
 	require.Nil(t, testSuite.orchestrator.L1Chain().Config().L2Config)
 
 	chains := testSuite.orchestrator.L2Chains()
 	require.Equal(t, len(chains), 2)
 
-	require.Equal(t, chains[0].ChainID(), uint64(10))
+	require.Equal(t, chains[0].ChainID(), uint64(901))
 	require.NotNil(t, chains[0].Config().L2Config)
-	require.Equal(t, chains[0].Config().L2Config.L1ChainID, uint64(1))
+	require.Equal(t, chains[0].Config().L2Config.L1ChainID, uint64(900))
 
-	require.Equal(t, chains[1].ChainID(), uint64(30))
+	require.Equal(t, chains[1].ChainID(), uint64(902))
 	require.NotNil(t, chains[1].Config().L2Config)
-	require.Equal(t, chains[1].Config().L2Config.L1ChainID, uint64(1))
+	require.Equal(t, chains[1].Config().L2Config.L1ChainID, uint64(900))
 }


### PR DESCRIPTION
Add support to parse either batch requests or normal json rpc requests.

The jsonrpc field can either be a string or numeric value. This causes 400s when a string since the current struct hard codes it to a uint. Fix this by switching this field to a `json.RawMessage` to defer decoding. We dont care about this field anyways.

