### PR TITLE
feat: handle batch responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ go.work.sum
 
 # vendored packages
 lib
+
+/main

--- a/opsimulator/json.go
+++ b/opsimulator/json.go
@@ -2,8 +2,17 @@ package opsimulator
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
+
+	"github.com/ethereum/go-ethereum/rpc"
 )
+
+type jsonError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
 
 // some parts copied over from op-geth as these are private
 
@@ -12,26 +21,39 @@ type jsonRpcMessage struct {
 	ID      json.RawMessage `json:"id,omitempty"`
 	Method  string          `json:"method,omitempty"`
 	Params  json.RawMessage `json:"params,omitempty"`
-
-	// Since we're just proxying back the response,
-	// no need to include the Error/Result fields
+	Error   *jsonError      `json:"error,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
 }
 
-func readJsonMessages(body io.Reader) ([]*jsonRpcMessage, error) {
+const (
+	vsn            = "2.0"
+	errcodeDefault = -32000
+	// Invalid method parameter(s).
+	InvalidParams = -32602
+	// Invalid JSON was received by the server.
+	// An error occurred on the server while parsing the JSON text.
+	ParseErr = -32700
+)
+
+var null = json.RawMessage("null")
+
+func readJsonMessages(body io.Reader) ([]*jsonRpcMessage, bool, error) {
 	var rawmsg json.RawMessage
 	if err := json.NewDecoder(body).Decode(&rawmsg); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	if !isJsonRpcBatch(rawmsg) {
+	isBatch := isJsonRpcBatch(rawmsg)
+
+	if !isBatch {
 		msgs := []*jsonRpcMessage{{}}
 		err := json.Unmarshal(rawmsg, &msgs[0])
-		return msgs, err
+		return msgs, isBatch, err
 	}
 
 	var msgs []*jsonRpcMessage
 	err := json.Unmarshal(rawmsg, &msgs)
-	return msgs, err
+	return msgs, isBatch, err
 }
 
 // isBatch returns true when the first non-whitespace characters is '['
@@ -44,4 +66,35 @@ func isJsonRpcBatch(raw json.RawMessage) bool {
 		return c == '['
 	}
 	return false
+}
+
+func errorMessage(err error) *jsonRpcMessage {
+	msg := &jsonRpcMessage{Version: vsn, ID: null, Error: &jsonError{
+		Code:    errcodeDefault,
+		Message: err.Error(),
+	}}
+	ec, ok := err.(rpc.Error)
+	if ok {
+		msg.Error.Code = ec.ErrorCode()
+	}
+	de, ok := err.(rpc.DataError)
+	if ok {
+		msg.Error.Data = de.ErrorData()
+	}
+	return msg
+}
+
+func (err *jsonError) Error() string {
+	if err.Message == "" {
+		return fmt.Sprintf("json-rpc error %d", err.Code)
+	}
+	return err.Message
+}
+
+func (err *jsonError) ErrorCode() int {
+	return err.Code
+}
+
+func (err *jsonError) ErrorData() interface{} {
+	return err.Data
 }

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -36,7 +36,11 @@ func NewOrchestrator(log log.Logger, networkConfig *config.NetworkConfig) (*Orch
 
 		l2Anvil := anvil.New(log, &cfg)
 		l2Anvils[cfg.ChainID] = l2Anvil
-		L2OpSims[cfg.ChainID] = opsimulator.New(log, nextL2Port, l1Anvil, l2Anvil, cfg.L2Config, l2Anvils)
+	}
+
+	for i := range networkConfig.L2Configs {
+		cfg := networkConfig.L2Configs[i]
+		L2OpSims[cfg.ChainID] = opsimulator.New(log, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], cfg.L2Config, l2Anvils)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {


### PR DESCRIPTION
Closes: https://github.com/ethereum-optimism/supersim/issues/55
Closes: https://github.com/ethereum-optimism/supersim/issues/79
Closes: https://github.com/ethereum-optimism/supersim/issues/92

Sets up proper response handling for batch requests. Specifically, when errors are encountered during batch requests, the entire response is not errored and just the specific request gets an `Error` field set.