### PR TITLE
feat(contracts): MockL2NativeSuperchainERC20

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "contracts/lib/optimism"]
+	path = contracts/lib/optimism
+	url = https://github.com/ethereum-optimism/optimism

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -6,3 +6,9 @@ libs = ["lib"]
 fs_permissions = [
   { access='read-write', path='../generated' },
 ]
+
+remappings = [
+  "@contracts-bedrock/=lib/optimism/packages/contracts-bedrock/src/",
+  "@solady/=lib/optimism/packages/contracts-bedrock/lib/solady/src/",
+  "@openzeppelin/contracts=lib/optimism/packages/contracts-bedrock/lib/openzeppelin-contracts/contracts"
+]

--- a/contracts/src/MockL2NativeSuperchainERC20.sol
+++ b/contracts/src/MockL2NativeSuperchainERC20.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ERC20} from "@solady/tokens/ERC20.sol";
+import {IL2ToL2CrossDomainMessenger} from "@contracts-bedrock/L2/IL2ToL2CrossDomainMessenger.sol";
+import {ISuperchainERC20Extensions} from "@contracts-bedrock/L2/ISuperchainERC20.sol";
+import {ISemver} from "@contracts-bedrock/universal/ISemver.sol";
+import {Predeploys} from "@contracts-bedrock/libraries/Predeploys.sol";
+
+/// @notice Thrown when attempting to relay a message and the function caller (msg.sender) is not
+/// L2ToL2CrossDomainMessenger.
+error CallerNotL2ToL2CrossDomainMessenger();
+
+/// @notice Thrown when attempting to relay a message and the cross domain message sender is not this
+/// OptimismSuperchainERC20.
+error InvalidCrossDomainSender();
+
+/// @notice Thrown when attempting to mint or burn tokens and the account is the zero address.
+error ZeroAddress();
+
+/// @title MockL2NativeSuperchainERC20
+/// @notice Mock implementation of a native Superchain ERC20 token that is L2 native (not backed by an L1 native token).
+/// The mint/burn functionality is intentionally open to ANYONE to make it easier to test with.
+contract MockL2NativeSuperchainERC20 is ISuperchainERC20Extensions, ERC20, ISemver {
+    /// @notice Emitted whenever tokens are minted for an account.
+    /// @param account Address of the account tokens are being minted for.
+    /// @param amount  Amount of tokens minted.
+    event Mint(address indexed account, uint256 amount);
+
+    /// @notice Emitted whenever tokens are burned from an account.
+    /// @param account Address of the account tokens are being burned from.
+    /// @param amount  Amount of tokens burned.
+    event Burn(address indexed account, uint256 amount);
+
+    /// @notice Address of the L2ToL2CrossDomainMessenger Predeploy.
+    address internal constant MESSENGER = Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER;
+
+    string public constant version = "0.0.1";
+
+    /// @notice Allows ANYONE to mint tokens.
+    /// @param _to     Address to mint tokens to.
+    /// @param _amount Amount of tokens to mint.
+    function mint(address _to, uint256 _amount) external virtual {
+        if (_to == address(0)) revert ZeroAddress();
+
+        _mint(_to, _amount);
+
+        emit Mint(_to, _amount);
+    }
+
+    /// @notice Allows ANYONE to burn tokens.
+    /// @param _from   Address to burn tokens from.
+    /// @param _amount Amount of tokens to burn.
+    function burn(address _from, uint256 _amount) external virtual {
+        if (_from == address(0)) revert ZeroAddress();
+
+        _burn(_from, _amount);
+
+        emit Burn(_from, _amount);
+    }
+
+    /// @notice Sends tokens to some target address on another chain.
+    /// @param _to      Address to send tokens to.
+    /// @param _amount  Amount of tokens to send.
+    /// @param _chainId Chain ID of the destination chain.
+    function sendERC20(address _to, uint256 _amount, uint256 _chainId) external {
+        if (_to == address(0)) revert ZeroAddress();
+
+        _burn(msg.sender, _amount);
+
+        bytes memory _message = abi.encodeCall(this.relayERC20, (msg.sender, _to, _amount));
+        IL2ToL2CrossDomainMessenger(MESSENGER).sendMessage(_chainId, address(this), _message);
+
+        emit SendERC20(msg.sender, _to, _amount, _chainId);
+    }
+
+    /// @notice Relays tokens received from another chain.
+    /// @param _from   Address of the msg.sender of sendERC20 on the source chain.
+    /// @param _to     Address to relay tokens to.
+    /// @param _amount Amount of tokens to relay.
+    function relayERC20(address _from, address _to, uint256 _amount) external {
+        if (_to == address(0)) revert ZeroAddress();
+
+        if (msg.sender != MESSENGER) revert CallerNotL2ToL2CrossDomainMessenger();
+
+        if (IL2ToL2CrossDomainMessenger(MESSENGER).crossDomainMessageSender() != address(this)) {
+            revert InvalidCrossDomainSender();
+        }
+
+        uint256 source = IL2ToL2CrossDomainMessenger(MESSENGER).crossDomainMessageSource();
+
+        _mint(_to, _amount);
+
+        emit RelayERC20(_from, _to, _amount, source);
+    }
+
+    function name() public pure virtual override returns (string memory) {
+        return "MockL2NativeSuperchainERC20";
+    }
+
+    function symbol() public pure virtual override returns (string memory) {
+        return "MOCK";
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 18;
+    }
+}

--- a/contracts/test/MockL2NativeSuperchainERC20.t.sol
+++ b/contracts/test/MockL2NativeSuperchainERC20.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Predeploys} from "@contracts-bedrock/libraries/Predeploys.sol";
+
+import {ERC20} from "@solady/tokens/ERC20.sol";
+
+import {
+    MockL2NativeSuperchainERC20,
+    CallerNotL2ToL2CrossDomainMessenger,
+    InvalidCrossDomainSender,
+    ZeroAddress
+} from "src/MockL2NativeSuperchainERC20.sol";
+import {IL2ToL2CrossDomainMessenger} from "@contracts-bedrock/L2/IL2ToL2CrossDomainMessenger.sol";
+import {ISuperchainERC20, ISuperchainERC20Extensions} from "@contracts-bedrock/L2/ISuperchainERC20.sol";
+
+contract MockL2NativeSuperchainERC20Test is Test {
+    address internal constant ZERO_ADDRESS = address(0);
+    address internal constant MESSENGER = Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER;
+
+    MockL2NativeSuperchainERC20 public superchainERC20;
+
+    /// @notice Helper function to setup a mock and expect a call to it.
+    function _mockAndExpect(address _receiver, bytes memory _calldata, bytes memory _returned) internal {
+        vm.mockCall(_receiver, _calldata, _returned);
+        vm.expectCall(_receiver, _calldata);
+    }
+
+    /// @notice Sets up the test suite.
+    function setUp() public {
+        superchainERC20 = new MockL2NativeSuperchainERC20();
+    }
+
+    function testFuzz_mint_succeeds(address _to, uint256 _amount) public {
+        // Ensure `_to` is not the zero address
+        vm.assume(_to != ZERO_ADDRESS);
+
+        // Get the total supply and balance of `_to` before the mint to compare later on the assertions
+        uint256 _totalSupplyBefore = superchainERC20.totalSupply();
+        uint256 _toBalanceBefore = superchainERC20.balanceOf(_to);
+
+        // Look for the emit of the `Transfer` event
+        vm.expectEmit(true, true, true, true, address(superchainERC20));
+        emit ERC20.Transfer(ZERO_ADDRESS, _to, _amount);
+
+        // Look for the emit of the `Mint` event
+        vm.expectEmit(true, true, true, true, address(superchainERC20));
+        emit MockL2NativeSuperchainERC20.Mint(_to, _amount);
+
+        superchainERC20.mint(_to, _amount);
+
+        assertEq(superchainERC20.totalSupply(), _totalSupplyBefore + _amount);
+        assertEq(superchainERC20.balanceOf(_to), _toBalanceBefore + _amount);
+    }
+
+    function testFuzz_mint_toZeroAddress_reverts(uint256 _amount) public {
+        // Expect the revert with `ZeroAddress` selector
+        vm.expectRevert(ZeroAddress.selector);
+
+        // Call the `mint` function with the zero address
+        superchainERC20.mint(ZERO_ADDRESS, _amount);
+    }
+
+    /// @notice Tests the `sendERC20` function burns the sender tokens, sends the message, and emits the `SendERC20`
+    /// event.
+    function testFuzz_sendERC20_succeeds(address _sender, address _to, uint256 _amount, uint256 _chainId) external {
+        // Ensure `_sender` is not the zero address
+        vm.assume(_sender != ZERO_ADDRESS);
+        vm.assume(_to != ZERO_ADDRESS);
+
+        // Mint some tokens to the sender so then they can be sent
+        superchainERC20.mint(_sender, _amount);
+
+        // Get the total supply and balance of `_sender` before the send to compare later on the assertions
+        uint256 _totalSupplyBefore = superchainERC20.totalSupply();
+        uint256 _senderBalanceBefore = superchainERC20.balanceOf(_sender);
+
+        // Look for the emit of the `Transfer` event
+        vm.expectEmit(true, true, true, true, address(superchainERC20));
+        emit ERC20.Transfer(_sender, ZERO_ADDRESS, _amount);
+
+        // Look for the emit of the `SendERC20` event
+        vm.expectEmit(true, true, true, true, address(superchainERC20));
+        emit ISuperchainERC20Extensions.SendERC20(_sender, _to, _amount, _chainId);
+
+        // Mock the call over the `sendMessage` function and expect it to be called properly
+        bytes memory _message = abi.encodeCall(superchainERC20.relayERC20, (_sender, _to, _amount));
+        _mockAndExpect(
+            MESSENGER,
+            abi.encodeWithSelector(
+                IL2ToL2CrossDomainMessenger.sendMessage.selector, _chainId, address(superchainERC20), _message
+            ),
+            abi.encode("")
+        );
+
+        // Call the `sendERC20` function
+        vm.prank(_sender);
+        superchainERC20.sendERC20(_to, _amount, _chainId);
+
+        // Check the total supply and balance of `_sender` after the send were updated correctly
+        assertEq(superchainERC20.totalSupply(), _totalSupplyBefore - _amount);
+        assertEq(superchainERC20.balanceOf(_sender), _senderBalanceBefore - _amount);
+    }
+
+    /// @notice Tests the `relayERC20` mints the proper amount and emits the `RelayERC20` event.
+    function testFuzz_relayERC20_succeeds(address _from, address _to, uint256 _amount, uint256 _source) public {
+        vm.assume(_from != ZERO_ADDRESS);
+        vm.assume(_to != ZERO_ADDRESS);
+
+        // Mock the call over the `crossDomainMessageSender` function setting the same address as value
+        _mockAndExpect(
+            MESSENGER,
+            abi.encodeWithSelector(IL2ToL2CrossDomainMessenger.crossDomainMessageSender.selector),
+            abi.encode(address(superchainERC20))
+        );
+
+        // Mock the call over the `crossDomainMessageSource` function setting the source chain ID as value
+        _mockAndExpect(
+            MESSENGER,
+            abi.encodeWithSelector(IL2ToL2CrossDomainMessenger.crossDomainMessageSource.selector),
+            abi.encode(_source)
+        );
+
+        // Get the total supply and balance of `_to` before the relay to compare later on the assertions
+        uint256 _totalSupplyBefore = superchainERC20.totalSupply();
+        uint256 _toBalanceBefore = superchainERC20.balanceOf(_to);
+
+        // Look for the emit of the `Transfer` event
+        vm.expectEmit(true, true, true, true, address(superchainERC20));
+        emit ERC20.Transfer(ZERO_ADDRESS, _to, _amount);
+
+        // Look for the emit of the `RelayERC20` event
+        vm.expectEmit(true, true, true, true, address(superchainERC20));
+        emit ISuperchainERC20Extensions.RelayERC20(_from, _to, _amount, _source);
+
+        // Call the `relayERC20` function with the messenger caller
+        vm.prank(MESSENGER);
+        superchainERC20.relayERC20(_from, _to, _amount);
+
+        // Check the total supply and balance of `_to` after the relay were updated correctly
+        assertEq(superchainERC20.totalSupply(), _totalSupplyBefore + _amount);
+        assertEq(superchainERC20.balanceOf(_to), _toBalanceBefore + _amount);
+    }
+}


### PR DESCRIPTION
context: https://github.com/ethereum-optimism/supersim/issues/89

heavily adapted from https://github.com/ethereum-optimism/optimism/pull/11256/files#diff-dcb1bb1a9a7da769141e9ae3cfe1209f666365a408ce8a2c856bc3597e65b0cd

Meant to be the most barebones implementation of the SuperchainERC20 that devs can test on supersim with.
- minted / burned natively on the L2 (no L1 bridging)
- mint / burn is permissionless, to make it easier for devs to test with
- this will be deployed to the supersim L2s at genesis, and tokens minted to the dev accounts by default

The ISuperchainERC20 and accompanying standards are constantly changing, so I'll keep this updated with the latest code in the monorepo when the event / function signatures change.
 