### PR TITLE
fix: sync clocks across anvil nodes on startup

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -73,7 +73,10 @@ func (a *Anvil) Start(ctx context.Context) error {
 		"--chain-id", fmt.Sprintf("%d", a.cfg.ChainID),
 		"--port", fmt.Sprintf("%d", a.cfg.Port),
 		"--optimism",
-		"--block-time", "2",
+	}
+
+	if a.cfg.StartingTimestamp > 0 {
+		args = append(args, "--timestamp", fmt.Sprintf("%d", a.cfg.StartingTimestamp))
 	}
 
 	if len(a.cfg.GenesisJSON) > 0 && a.cfg.ForkConfig == nil {
@@ -312,4 +315,8 @@ func (a *Anvil) SetCode(ctx context.Context, result interface{}, address string,
 
 func (a *Anvil) SetStorageAt(ctx context.Context, result interface{}, address string, storageSlot string, storageValue string) error {
 	return a.rpcClient.CallContext(ctx, result, "anvil_setStorageAt", address, storageSlot, storageValue)
+}
+
+func (a *Anvil) SetIntervalMining(ctx context.Context, result interface{}, interval int64) error {
+	return a.rpcClient.CallContext(ctx, result, "evm_setIntervalMining", interval)
 }

--- a/config/chain.go
+++ b/config/chain.go
@@ -24,39 +24,6 @@ var (
 		Mnemonic:       "test test test test test test test test test test test junk",
 		DerivationPath: accounts.DefaultRootDerivationPath,
 	}
-
-	DefaultNetworkConfig = NetworkConfig{
-		L1Config: ChainConfig{
-			Name:          "L1",
-			ChainID:       genesis.GeneratedGenesisDeployment.L1.ChainID,
-			SecretsConfig: DefaultSecretsConfig,
-			GenesisJSON:   genesis.GeneratedGenesisDeployment.L1.GenesisJSON,
-		},
-		L2Configs: []ChainConfig{
-			{
-				Name:          "OPChainA",
-				ChainID:       genesis.GeneratedGenesisDeployment.L2s[0].ChainID,
-				SecretsConfig: DefaultSecretsConfig,
-				GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[0].GenesisJSON,
-				L2Config: &L2Config{
-					L1ChainID:     genesis.GeneratedGenesisDeployment.L1.ChainID,
-					L1Addresses:   genesis.GeneratedGenesisDeployment.L2s[0].RegistryAddressList(),
-					DependencySet: []uint64{genesis.GeneratedGenesisDeployment.L2s[1].ChainID},
-				},
-			},
-			{
-				Name:          "OPChainB",
-				ChainID:       genesis.GeneratedGenesisDeployment.L2s[1].ChainID,
-				SecretsConfig: DefaultSecretsConfig,
-				GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[1].GenesisJSON,
-				L2Config: &L2Config{
-					L1ChainID:     genesis.GeneratedGenesisDeployment.L1.ChainID,
-					L1Addresses:   genesis.GeneratedGenesisDeployment.L2s[1].RegistryAddressList(),
-					DependencySet: []uint64{genesis.GeneratedGenesisDeployment.L2s[0].ChainID},
-				},
-			},
-		},
-	}
 )
 
 type ForkConfig struct {
@@ -90,6 +57,9 @@ type ChainConfig struct {
 
 	// Optional Config (L1 chain if nil)
 	L2Config *L2Config
+
+	// Optional
+	StartingTimestamp uint64
 }
 
 type NetworkConfig struct {
@@ -147,6 +117,45 @@ type Chain interface {
 	DebugTraceCall(ctx context.Context, txArgs TransactionArgs) (TraceCallRaw, error)
 	SetCode(ctx context.Context, result interface{}, address string, code string) error
 	SetStorageAt(ctx context.Context, result interface{}, address string, storageSlot string, storageValue string) error
+	SetIntervalMining(ctx context.Context, result interface{}, interval int64) error
+}
+
+func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {
+	return NetworkConfig{
+		L1Config: ChainConfig{
+			Name:              "L1",
+			ChainID:           genesis.GeneratedGenesisDeployment.L1.ChainID,
+			SecretsConfig:     DefaultSecretsConfig,
+			GenesisJSON:       genesis.GeneratedGenesisDeployment.L1.GenesisJSON,
+			StartingTimestamp: startingTimestamp,
+		},
+		L2Configs: []ChainConfig{
+			{
+				Name:          "OPChainA",
+				ChainID:       genesis.GeneratedGenesisDeployment.L2s[0].ChainID,
+				SecretsConfig: DefaultSecretsConfig,
+				GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[0].GenesisJSON,
+				L2Config: &L2Config{
+					L1ChainID:     genesis.GeneratedGenesisDeployment.L1.ChainID,
+					L1Addresses:   genesis.GeneratedGenesisDeployment.L2s[0].RegistryAddressList(),
+					DependencySet: []uint64{genesis.GeneratedGenesisDeployment.L2s[1].ChainID},
+				},
+				StartingTimestamp: startingTimestamp,
+			},
+			{
+				Name:          "OPChainB",
+				ChainID:       genesis.GeneratedGenesisDeployment.L2s[1].ChainID,
+				SecretsConfig: DefaultSecretsConfig,
+				GenesisJSON:   genesis.GeneratedGenesisDeployment.L2s[1].GenesisJSON,
+				L2Config: &L2Config{
+					L1ChainID:     genesis.GeneratedGenesisDeployment.L1.ChainID,
+					L1Addresses:   genesis.GeneratedGenesisDeployment.L2s[1].RegistryAddressList(),
+					DependencySet: []uint64{genesis.GeneratedGenesisDeployment.L2s[0].ChainID},
+				},
+				StartingTimestamp: startingTimestamp,
+			},
+		},
+	}
 }
 
 // Note: The default secrets config is used everywhere

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/supersim/config"
 
@@ -20,9 +21,9 @@ type TestSuite struct {
 }
 
 func createTestSuite(t *testing.T) *TestSuite {
-	networkConfig := &config.DefaultNetworkConfig
+	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()))
 	testlog := testlog.Logger(t, log.LevelInfo)
-	orchestrator, _ := NewOrchestrator(testlog, networkConfig)
+	orchestrator, _ := NewOrchestrator(testlog, &networkConfig)
 	t.Cleanup(func() {
 		if err := orchestrator.Stop(context.Background()); err != nil {
 			t.Errorf("failed to stop orchestrator: %s", err)

--- a/supersim.go
+++ b/supersim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	registry "github.com/ethereum-optimism/superchain-registry/superchain"
 	"github.com/ethereum-optimism/supersim/config"
@@ -18,7 +19,7 @@ type Supersim struct {
 }
 
 func NewSupersim(log log.Logger, envPrefix string, cliConfig *config.CLIConfig) (*Supersim, error) {
-	networkConfig := config.DefaultNetworkConfig
+	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()))
 	if cliConfig.ForkConfig != nil {
 		superchain := registry.Superchains[cliConfig.ForkConfig.Network]
 		log.Info("generating fork configuration", "superchain", superchain.Superchain)

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -84,3 +84,7 @@ func (c *MockChain) SetCode(ctx context.Context, result interface{}, address str
 func (c *MockChain) SetStorageAt(ctx context.Context, result interface{}, address string, storageSlot string, storageValue string) error {
 	return nil
 }
+
+func (c *MockChain) SetIntervalMining(ctx context.Context, result interface{}, interval int64) error {
+	return nil
+}


### PR DESCRIPTION
Closes: https://github.com/ethereum-optimism/supersim/issues/102
Closes: https://github.com/ethereum-optimism/supersim/issues/100

This PR synchronizes the anvil block timestamps across all L2 nodes prior to supersim startup. This is done using the following steps:
1. start the nodes in automine mode so no new blocks are created
2. turn on 2 second interval mining for all nodes using a goroutine after all anvil nodes have marked themselves as ready using `evm_setIntervalMining`

This synchronization is not perfect but it should ensure that the clocks between anvil nodes never drift further than 2 seconds apart.