### PR TITLE
fixes: anvil & chain abstraction

### DIFF
--- a/config/chain.go
+++ b/config/chain.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ethereum-optimism/supersim/hdaccount"
 
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -65,35 +63,6 @@ type NetworkConfig struct {
 
 	L2StartingPort uint64
 	L2Configs      []ChainConfig
-}
-
-type TransactionArgs struct {
-	From     common.Address  `json:"from"`
-	To       *common.Address `json:"to"`
-	Gas      hexutil.Uint64  `json:"gas"`
-	GasPrice *hexutil.Big    `json:"gasPrice"`
-	Data     hexutil.Bytes   `json:"data"`
-	Value    *hexutil.Big    `json:"value"`
-}
-
-type TraceCallRaw struct {
-	Error   *string            `json:"error,omitempty"`
-	Type    string             `json:"type"`
-	From    string             `json:"from"`
-	To      string             `json:"to"`
-	Value   string             `json:"value"`
-	Gas     string             `json:"gas"`
-	GasUsed string             `json:"gasUsed"`
-	Input   string             `json:"input"`
-	Output  string             `json:"output"`
-	Logs    []*TraceCallRawLog `json:"logs"`
-	Calls   []TraceCallRaw     `json:"calls"`
-}
-
-type TraceCallRawLog struct {
-	Address common.Address `json:"address"`
-	Topics  []common.Hash  `json:"topics"`
-	Data    string         `json:"data"`
 }
 
 type Chain interface {

--- a/config/chain.go
+++ b/config/chain.go
@@ -3,14 +3,12 @@ package config
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"strings"
 
 	registry "github.com/ethereum-optimism/superchain-registry/superchain"
 	"github.com/ethereum-optimism/supersim/genesis"
 	"github.com/ethereum-optimism/supersim/hdaccount"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -106,15 +104,7 @@ type Chain interface {
 	Config() *ChainConfig
 	EthClient() *ethclient.Client
 
-	// TODO: Delete these and use EthClient directly
-	// API methods
-	EthGetCode(ctx context.Context, account common.Address) ([]byte, error)
-	EthGetLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
-	EthSendTransaction(ctx context.Context, tx *types.Transaction) error
-	EthBlockByNumber(ctx context.Context, blockHeight *big.Int) (*types.Block, error)
-
-	SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
-	DebugTraceCall(ctx context.Context, txArgs TransactionArgs) (TraceCallRaw, error)
+	SimulatedLogs(ctx context.Context, tx *types.Transaction) ([]types.Log, error)
 	SetCode(ctx context.Context, result interface{}, address string, code string) error
 	SetStorageAt(ctx context.Context, result interface{}, address string, storageSlot string, storageValue string) error
 	SetIntervalMining(ctx context.Context, result interface{}, interval int64) error

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -42,7 +42,9 @@ func NewOrchestrator(log log.Logger, networkConfig *config.NetworkConfig) (*Orch
 
 	for i := range networkConfig.L2Configs {
 		cfg := networkConfig.L2Configs[i]
-		l2OpSims[cfg.ChainID] = opsimulator.New(log, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], cfg.L2Config, l2Anvils)
+
+		l2Anvil := l2Anvils[cfg.ChainID]
+		l2OpSims[cfg.ChainID] = opsimulator.New(log, nextL2Port, l1Anvil, l2Anvil, l2Anvils)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {
@@ -63,10 +65,6 @@ func (o *Orchestrator) Start(ctx context.Context) error {
 		if err := anvil.Start(ctx); err != nil {
 			return fmt.Errorf("anvil instance %s failed to start: %w", anvil.Name(), err)
 		}
-	}
-
-	if err := o.WaitUntilAnvilsAreReady(); err != nil {
-		return fmt.Errorf("anvil instances failed to get ready: %w", err)
 	}
 
 	for _, opSim := range o.l2OpSims {
@@ -102,67 +100,6 @@ func (o *Orchestrator) Stop(ctx context.Context) error {
 	}
 
 	return errors.Join(errs...)
-}
-
-func (o *Orchestrator) Stopped() bool {
-	if stopped := o.l1Anvil.Stopped(); stopped {
-		return stopped
-	}
-	for _, anvil := range o.l2Anvils {
-		if stopped := anvil.Stopped(); !stopped {
-			return stopped
-		}
-	}
-	for _, opSim := range o.l2OpSims {
-		if stopped := opSim.Stopped(); !stopped {
-			return stopped
-		}
-	}
-	return true
-}
-
-func (o *Orchestrator) WaitUntilAnvilsAreReady() error {
-	var once sync.Once
-	var err error
-	ctx, cancel := context.WithCancel(context.Background())
-
-	handleErr := func(e error) {
-		if e == nil {
-			return
-		}
-
-		once.Do(func() {
-			err = e
-			cancel()
-		})
-	}
-
-	var wg sync.WaitGroup
-	anvils := []*anvil.Anvil{o.l1Anvil}
-	for _, chain := range o.l2Anvils {
-		anvils = append(anvils, chain)
-	}
-
-	waitForAnvil := func(anvil *anvil.Anvil) {
-		defer wg.Done()
-		handleErr(anvil.WaitUntilReady(ctx))
-	}
-	for _, chain := range anvils {
-		wg.Add(1)
-		go waitForAnvil(chain)
-	}
-
-	wg.Wait()
-
-	if err != nil {
-		return err
-	}
-
-	if err := o.kickOffMining(ctx, anvils); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (o *Orchestrator) kickOffMining(ctx context.Context, anvils []*anvil.Anvil) error {

--- a/supersim.go
+++ b/supersim.go
@@ -77,8 +77,9 @@ func (s *Supersim) Stop(ctx context.Context) error {
 	return nil
 }
 
+// no-op dead code in the cliapp lifecycle
 func (s *Supersim) Stopped() bool {
-	return s.Orchestrator.Stopped()
+	return false
 }
 
 func (s *Supersim) ConfigAsString() string {

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -205,16 +205,18 @@ func TestStartup(t *testing.T) {
 
 func TestL1GenesisState(t *testing.T) {
 	testSuite := createTestSuite(t, &config.CLIConfig{})
+
+	l1Client := testSuite.Supersim.Orchestrator.L1Chain().EthClient()
 	for _, chain := range testSuite.Supersim.Orchestrator.L2Chains() {
 		require.NotNil(t, chain.Config().L2Config)
 
 		l1Addrs := chain.Config().L2Config.L1Addresses
 
-		code, err := testSuite.Supersim.Orchestrator.L1Chain().EthGetCode(context.Background(), common.Address(l1Addrs.AddressManager))
+		code, err := l1Client.CodeAt(context.Background(), common.Address(l1Addrs.AddressManager), nil)
 		require.Nil(t, err)
 		require.NotEqual(t, emptyCode, code, "AddressManager is not deployed")
 
-		code, err = testSuite.Supersim.Orchestrator.L1Chain().EthGetCode(context.Background(), common.Address(l1Addrs.OptimismPortalProxy))
+		code, err = l1Client.CodeAt(context.Background(), common.Address(l1Addrs.OptimismPortalProxy), nil)
 		require.Nil(t, err)
 		require.NotEqual(t, emptyCode, code, "OptimismPortalProxy is not deployed")
 	}

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -2,12 +2,9 @@ package testutils
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/ethereum-optimism/supersim/config"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -53,28 +50,8 @@ func (c *MockChain) EthClient() *ethclient.Client {
 	return nil
 }
 
-func (c *MockChain) EthGetCode(ctx context.Context, account common.Address) ([]byte, error) {
-	return []byte{}, nil
-}
-
-func (c *MockChain) EthGetLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
-	return []types.Log{}, nil
-}
-
-func (c *MockChain) EthSendTransaction(ctx context.Context, tx *types.Transaction) error {
-	return nil
-}
-
-func (c *MockChain) EthBlockByNumber(ctx context.Context, blockHeight *big.Int) (*types.Block, error) {
-	return &types.Block{}, nil
-}
-
-func (c *MockChain) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
-	return &MockSubscription{}, nil
-}
-
-func (c *MockChain) DebugTraceCall(ctx context.Context, txArgs config.TransactionArgs) (config.TraceCallRaw, error) {
-	return config.TraceCallRaw{}, nil
+func (c *MockChain) SimulatedLogs(ctx context.Context, tx *types.Transaction) ([]types.Log, error) {
+	return nil, nil
 }
 
 func (c *MockChain) SetCode(ctx context.Context, result interface{}, address string, code string) error {


### PR DESCRIPTION
Closes #107 

- Remove `EthClient` interface from `Chain`
- Make log simulation apart of the interface to simply code and remove public type arguments
- `--optimism` only if L2
- `Stopped` deadcode. Remove from orchestrator,anvil,opsim. And just return false in `Supersim`
- Remove `WaitUntilReady` as all the processes already pause until started
- Make some types internal