### PR TITLE
fix: opsim is follows the config.Chain abstraction

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -194,7 +194,7 @@ func (a *Anvil) Start(ctx context.Context) error {
 	return nil
 }
 
-func (a *Anvil) Stop() error {
+func (a *Anvil) Stop(_ context.Context) error {
 	if a.stopped.Load() {
 		return errors.New("already stopped")
 	}

--- a/config/chain.go
+++ b/config/chain.go
@@ -66,17 +66,22 @@ type NetworkConfig struct {
 }
 
 type Chain interface {
-	Name() string
+	// Properties
 	Endpoint() string
-	ChainID() uint64
 	LogPath() string
+	String() string
 	Config() *ChainConfig
 	EthClient() *ethclient.Client
 
+	// Additional methods
 	SimulatedLogs(ctx context.Context, tx *types.Transaction) ([]types.Log, error)
 	SetCode(ctx context.Context, result interface{}, address string, code string) error
 	SetStorageAt(ctx context.Context, result interface{}, address string, storageSlot string, storageValue string) error
 	SetIntervalMining(ctx context.Context, result interface{}, interval int64) error
+
+	// Lifecycle
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
 }
 
 func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -41,20 +41,20 @@ func createTestSuite(t *testing.T) *TestSuite {
 func TestStartup(t *testing.T) {
 	testSuite := createTestSuite(t)
 
-	require.Equal(t, testSuite.orchestrator.L1Chain().ChainID(), uint64(900))
+	require.Equal(t, testSuite.orchestrator.L1Chain().Config().ChainID, uint64(900))
 	require.Nil(t, testSuite.orchestrator.L1Chain().Config().L2Config)
 
 	chains := testSuite.orchestrator.L2Chains()
 	require.Equal(t, len(chains), 2)
 
 	require.True(t, slices.ContainsFunc(chains, func(chain config.Chain) bool {
-		return chain.ChainID() == uint64(901)
+		return chain.Config().ChainID == uint64(901)
 	}))
 	require.NotNil(t, chains[0].Config().L2Config)
 	require.Equal(t, chains[0].Config().L2Config.L1ChainID, uint64(900))
 
 	require.True(t, slices.ContainsFunc(chains, func(chain config.Chain) bool {
-		return chain.ChainID() == uint64(902)
+		return chain.Config().ChainID == uint64(902)
 	}))
 	require.NotNil(t, chains[1].Config().L2Config)
 	require.Equal(t, chains[1].Config().L2Config.L1ChainID, uint64(900))

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -187,7 +187,7 @@ func TestStartup(t *testing.T) {
 
 		var chainId math.HexOrDecimal64
 		require.NoError(t, l2Client.CallContext(context.Background(), &chainId, "eth_chainId"))
-		require.Equal(t, chain.ChainID(), uint64(chainId))
+		require.Equal(t, chain.Config().ChainID, uint64(chainId))
 
 		l2Client.Close()
 	}
@@ -198,7 +198,7 @@ func TestStartup(t *testing.T) {
 
 	var chainId math.HexOrDecimal64
 	require.NoError(t, l1Client.CallContext(context.Background(), &chainId, "eth_chainId"))
-	require.Equal(t, testSuite.Supersim.Orchestrator.L1Chain().ChainID(), uint64(chainId))
+	require.Equal(t, testSuite.Supersim.Orchestrator.L1Chain().Config().ChainID, uint64(chainId))
 
 	l1Client.Close()
 }
@@ -280,7 +280,7 @@ func TestDepositTxSimpleEthDeposit(t *testing.T) {
 			oneEth := big.NewInt(1e18)
 			prevBalance, _ := l2EthClient.BalanceAt(context.Background(), senderAddress, nil)
 
-			transactor, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(l1Chain.ChainID())))
+			transactor, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(l1Chain.Config().ChainID)))
 			transactor.Value = oneEth
 			optimismPortal, _ := opbindings.NewOptimismPortal(common.Address(chain.Config().L2Config.L1Addresses.OptimismPortalProxy), l1EthClient)
 
@@ -312,7 +312,7 @@ func TestDependencySet(t *testing.T) {
 	testSuite := createTestSuite(t, &config.CLIConfig{})
 
 	for _, chain := range testSuite.Supersim.Orchestrator.L2Chains() {
-		l2Client, err := ethclient.Dial(testSuite.Supersim.Orchestrator.Endpoint(chain.ChainID()))
+		l2Client, err := ethclient.Dial(testSuite.Supersim.Orchestrator.Endpoint(chain.Config().ChainID))
 		require.NoError(t, err)
 		defer l2Client.Close()
 
@@ -359,7 +359,7 @@ func TestDeployContractsL1WithDevAccounts(t *testing.T) {
 			senderAddress := common.HexToAddress(senderAddressHex)
 
 			for range 5 {
-				transactor, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(testSuite.Supersim.Orchestrator.L1Chain().ChainID())))
+				transactor, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(testSuite.Supersim.Orchestrator.L1Chain().Config().ChainID)))
 
 				// Test deploying a contract with CREATE
 				_, tx, _, err := opbindings.DeployProxyAdmin(transactor, l1Client, senderAddress)
@@ -381,7 +381,7 @@ func TestBatchJsonRpcRequests(t *testing.T) {
 	testSuite := createTestSuite(t, &config.CLIConfig{})
 
 	for _, chain := range testSuite.Supersim.Orchestrator.L2Chains() {
-		client, err := ethclient.Dial(testSuite.Supersim.Orchestrator.Endpoint(chain.ChainID()))
+		client, err := ethclient.Dial(testSuite.Supersim.Orchestrator.Endpoint(chain.Config().ChainID))
 		require.NoError(t, err)
 		defer client.Close()
 

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -26,14 +26,6 @@ func NewMockChain() *MockChain {
 	return &MockChain{}
 }
 
-func (c *MockChain) Name() string {
-	return "mockchain"
-}
-
-func (c *MockChain) ChainID() uint64 {
-	return 1
-}
-
 func (c *MockChain) Endpoint() string {
 	return "http://localhost:8545"
 }
@@ -42,7 +34,22 @@ func (c *MockChain) LogPath() string {
 	return "var/chain/log"
 }
 
+func (c *MockChain) String() string {
+	return "mockchain"
+}
+
 func (c *MockChain) Config() *config.ChainConfig {
+	return &config.ChainConfig{
+		Name:    "mockchain",
+		ChainID: 1,
+	}
+}
+
+func (c *MockChain) Start(_ context.Context) error {
+	return nil
+}
+
+func (c *MockChain) Stop(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
In order to not leak the underlying chain type, opsim should also be a `config.Chain` when wrapping the L2 chain. This can easily be done by embedding the l2 chain in the opsim struct.

Now all references in the orchestrator and supersim can use `config.Chain` regardless if it's fronted by opsim or not


**aside**: The interface doesn't need methods for `Name()` and `ChainID()` as these are already available via the config struct