### PR TITLE
feat(l2tol2msg): create autorelayer mode

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -19,8 +19,10 @@ const (
 
 	ChainsFlagName         = "chains"
 	NetworkFlagName        = "network"
-	InteropFlagName        = "experiment.interop"
 	L2StartingPortFlagName = "l2.starting.port"
+
+	InteropEnabledInForkModeFlagName = "interop.enabled"
+	InteropAutoRelayFlagName         = "interop.autorelay"
 )
 
 func BaseCLIFlags(envPrefix string) []cli.Flag {
@@ -36,6 +38,12 @@ func BaseCLIFlags(envPrefix string) []cli.Flag {
 			Usage:   "Starting port to increment from for L2 chains. `0` binds each chain to any available port",
 			Value:   9545,
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "L2_STARTING_PORT"),
+		},
+		&cli.BoolFlag{
+			Name:    InteropAutoRelayFlagName,
+			Value:   false,
+			Usage:   "Automatically relay messages sent to the L2ToL2CrossDomainMessenger using account 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "AUTORELAY"),
 		},
 	}
 }
@@ -63,7 +71,7 @@ func ForkCLIFlags(envPrefix string) []cli.Flag {
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "NETWORK"),
 		},
 		&cli.BoolFlag{
-			Name:    InteropFlagName,
+			Name:    InteropEnabledInForkModeFlagName,
 			Value:   false,
 			Usage:   "Enable interop in fork mode",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "FORK_WITH_INTEROP"),
@@ -79,16 +87,18 @@ type ForkCLIConfig struct {
 }
 
 type CLIConfig struct {
-	L1Port         uint64
-	L2StartingPort uint64
+	L1Port           uint64
+	L2StartingPort   uint64
+	InteropAutoRelay bool
 
 	ForkConfig *ForkCLIConfig
 }
 
 func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 	cfg := &CLIConfig{
-		L1Port:         ctx.Uint64(L1PortFlagName),
-		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
+		L1Port:           ctx.Uint64(L1PortFlagName),
+		L2StartingPort:   ctx.Uint64(L2StartingPortFlagName),
+		InteropAutoRelay: ctx.Bool(InteropAutoRelayFlagName),
 	}
 
 	if ctx.Command.Name == ForkCommandName {
@@ -96,7 +106,7 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 			L1ForkHeight: ctx.Uint64(L1ForkHeightFlagName),
 			Network:      ctx.String(NetworkFlagName),
 			Chains:       ctx.StringSlice(ChainsFlagName),
-			UseInterop:   ctx.Bool(InteropFlagName),
+			UseInterop:   ctx.Bool(InteropEnabledInForkModeFlagName),
 		}
 	}
 

--- a/l2tol2msg/indexer_test.go
+++ b/l2tol2msg/indexer_test.go
@@ -129,7 +129,7 @@ func TestProcessEventLogFailedRelayedMessage(t *testing.T) {
 	require.Equal(t, entry.Lifecycle().SentTxHash, sentMessageLog.TxHash)
 	require.Equal(t, entry.Lifecycle().FailedTxHashes[0], failedRelayedMessageLog.TxHash)
 
-	// process another FailedRelayedMessage event
+	// process FailedRelayedMessage event 2
 	err = indexer.processEventLog(context.Background(), mockChainReader, sourceChainID, &failedRelayedMessageLog)
 	require.NoError(t, err)
 

--- a/l2tol2msg/relayer.go
+++ b/l2tol2msg/relayer.go
@@ -1,0 +1,103 @@
+package l2tol2msg
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/tasks"
+	"github.com/ethereum-optimism/supersim/bindings"
+	"github.com/ethereum-optimism/supersim/config"
+	"github.com/ethereum-optimism/supersim/hdaccount"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type L2ToL2MessageRelayer struct {
+	l2ToL2MessageIndexer *L2ToL2MessageIndexer
+
+	clients map[uint64]*ethclient.Client
+
+	tasks       tasks.Group
+	tasksCtx    context.Context
+	tasksCancel context.CancelFunc
+}
+
+func NewL2ToL2MessageRelayer() *L2ToL2MessageRelayer {
+	tasksCtx, tasksCancel := context.WithCancel(context.Background())
+
+	return &L2ToL2MessageRelayer{
+		tasks: tasks.Group{
+			HandleCrit: func(err error) {
+				fmt.Printf("unhandled indexer error: %v\n", err)
+			},
+		},
+		tasksCtx:    tasksCtx,
+		tasksCancel: tasksCancel,
+	}
+
+}
+
+func (r *L2ToL2MessageRelayer) Start(indexer *L2ToL2MessageIndexer, clients map[uint64]*ethclient.Client) error {
+	r.l2ToL2MessageIndexer = indexer
+	r.clients = clients
+
+	hdAccountStore, err := hdaccount.NewHdAccountStore(config.DefaultSecretsConfig.Mnemonic, config.DefaultSecretsConfig.DerivationPath)
+	if err != nil {
+		return fmt.Errorf("failed to create hd account store: %w", err)
+	}
+
+	privateKey, err := hdAccountStore.DerivePrivateKeyAt(9)
+	if err != nil {
+		return fmt.Errorf("failed to derive private key: %w", err)
+	}
+
+	for destinationChainID, client := range r.clients {
+		r.tasks.Go(func() error {
+			sentMessageCh := make(chan *L2ToL2MessageStoreEntry)
+			unsubscribe, err := r.l2ToL2MessageIndexer.SubscribeSentMessageToDestination(destinationChainID, sentMessageCh)
+
+			if err != nil {
+				return fmt.Errorf("failed to subscribe to sent message events: %w", err)
+			}
+
+			transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(destinationChainID)))
+			if err != nil {
+				return fmt.Errorf("failed to create transactor: %w", err)
+			}
+
+			crossL2Inbox, err := bindings.NewCrossL2InboxTransactor(predeploys.CrossL2InboxAddr, client)
+			if err != nil {
+				return fmt.Errorf("failed to create	transactor: %w", err)
+			}
+
+			for {
+				select {
+				case <-r.tasksCtx.Done():
+					unsubscribe()
+					close(sentMessageCh)
+					return nil
+				case sentMessage := <-sentMessageCh:
+					identifier := sentMessage.Identifier()
+					msg := sentMessage.Message()
+					calldata, err := msg.EventData()
+					if err != nil {
+						return fmt.Errorf("failed to get event data: %w", err)
+					}
+
+					if _, err = crossL2Inbox.ExecuteMessage(transactor, *identifier, predeploys.L2toL2CrossDomainMessengerAddr, calldata); err != nil {
+						return fmt.Errorf("failed to execute message: %w", err)
+					}
+				}
+			}
+
+		})
+	}
+
+	return nil
+}
+
+func (r *L2ToL2MessageRelayer) Stop(ctx context.Context) {
+	r.tasksCancel()
+}

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -25,7 +25,7 @@ func createTestSuite(t *testing.T) *TestSuite {
 	testlog := testlog.Logger(t, log.LevelInfo)
 
 	ctx, closeApp := context.WithCancelCause(context.Background())
-	orchestrator, _ := NewOrchestrator(testlog, closeApp, &networkConfig)
+	orchestrator, _ := NewOrchestrator(testlog, closeApp, &networkConfig, false)
 	t.Cleanup(func() {
 		closeApp(nil)
 		if err := orchestrator.Stop(context.Background()); err != nil {

--- a/supersim.go
+++ b/supersim.go
@@ -47,7 +47,7 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 	cfg.L1Config.Port = cliConfig.L1Port
 	cfg.L2StartingPort = cliConfig.L2StartingPort
 
-	o, err := orchestrator.NewOrchestrator(log, closeApp, &cfg)
+	o, err := orchestrator.NewOrchestrator(log, closeApp, &cfg, cliConfig.InteropAutoRelay)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create orchestrator")
 	}


### PR DESCRIPTION
- adds new flag `supersim --autorelay` 
- this mode automatically relays messages sent to the L2ToL2CrossDomainMessenger using this account `0xa0Ee7A142d267C1f36714E4a8F75612F20a79720`
    - in the future we can make the sender configurable too
- creates an `L2ToL2MessageRelayer` that listens to send events using the `L2ToL2MessageIndexer` then sends the corresponding relayMessage tx on the destination chain
- right now the opsim proxy does not support ws connections, making unsuitable for the `L2ToL2MessageIndexer` which uses ws subscriptions. `L2ToL2MessageIndexer` directly calls the underlying chain RPC, bypassing opsim. 
- `L2ToL2MessageRelayer` sends tx through the opsim proxy, so all invariant checks should happen
- as soon as a `SentMessage` log is emitted (ie. block is mined) on the source chain, the `relayMessage` call is sent on the destination chain. This is fine because we don't enforce any custom delays for the sequencer accepting logs. Will update accordingly when that feature gets added