### PR TITLE
chore: supersim changes from demo

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -236,12 +236,6 @@ func (a *Anvil) Config() *config.ChainConfig {
 	return a.cfg
 }
 
-func (a *Anvil) String() string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "Name: %s    Chain ID: %d    RPC: %s    LogPath: %s", a.Name(), a.ChainID(), a.Endpoint(), a.LogPath())
-	return b.String()
-}
-
 func (a *Anvil) EthClient() *ethclient.Client {
 	return a.ethClient
 }

--- a/config/chain.go
+++ b/config/chain.go
@@ -69,7 +69,6 @@ type Chain interface {
 	// Properties
 	Endpoint() string
 	LogPath() string
-	String() string
 	Config() *ChainConfig
 	EthClient() *ethclient.Client
 
@@ -87,7 +86,7 @@ type Chain interface {
 func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {
 	return NetworkConfig{
 		L1Config: ChainConfig{
-			Name:              "L1",
+			Name:              "Local",
 			ChainID:           genesis.GeneratedGenesisDeployment.L1.ChainID,
 			SecretsConfig:     DefaultSecretsConfig,
 			GenesisJSON:       genesis.GeneratedGenesisDeployment.L1.GenesisJSON,

--- a/opsimulator/json.go
+++ b/opsimulator/json.go
@@ -30,8 +30,11 @@ type jsonRpcMessage struct {
 }
 
 func readJsonMessages(body io.Reader) ([]*jsonRpcMessage, bool, error) {
+	dec := json.NewDecoder(body)
+	dec.UseNumber()
+
 	var rawmsg json.RawMessage
-	if err := json.NewDecoder(body).Decode(&rawmsg); err != nil {
+	if err := dec.Decode(&rawmsg); err != nil {
 		return nil, false, err
 	}
 

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -82,11 +82,9 @@ func (o *Orchestrator) Start(ctx context.Context) error {
 		}
 	}
 
-	/*
-		if err := o.kickOffMining(ctx); err != nil {
-			return fmt.Errorf("unable to start mining: %w", err)
-		}
-	*/
+	if err := o.kickOffMining(ctx); err != nil {
+		return fmt.Errorf("unable to start mining: %w", err)
+	}
 
 	// TODO: hack until opsim proxy supports websocket connections.
 	// We need websocket connections to make subscriptions.

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -82,9 +82,11 @@ func (o *Orchestrator) Start(ctx context.Context) error {
 		}
 	}
 
-	if err := o.kickOffMining(ctx); err != nil {
-		return fmt.Errorf("unable to start mining: %w", err)
-	}
+	/*
+		if err := o.kickOffMining(ctx); err != nil {
+			return fmt.Errorf("unable to start mining: %w", err)
+		}
+	*/
 
 	// TODO: hack until opsim proxy supports websocket connections.
 	// We need websocket connections to make subscriptions.
@@ -202,14 +204,11 @@ func (o *Orchestrator) Endpoint(chainId uint64) string {
 
 func (o *Orchestrator) ConfigAsString() string {
 	var b strings.Builder
-
-	if o.l1Chain != nil {
-		fmt.Fprintf(&b, "L1:\n")
-		fmt.Fprintf(&b, "  %s\n", o.l1Chain.String())
-	}
+	l1Cfg := o.l1Chain.Config()
+	fmt.Fprintf(&b, "L1: Name: %s  ChainID: %d  RPC: %s  LogPath: %s\n", l1Cfg.Name, l1Cfg.ChainID, o.l1Chain.Endpoint(), o.l1Chain.LogPath())
 
 	if len(o.l2OpSims) > 0 {
-		fmt.Fprintf(&b, "L2:\n")
+		fmt.Fprintf(&b, "\nL2s: Predeploy Contracts Spec ( %s )\n", "https://specs.optimism.io/protocol/predeploys.html")
 
 		opSims := make([]*opsimulator.OpSimulator, 0, len(o.l2OpSims))
 		for _, chain := range o.l2OpSims {
@@ -219,7 +218,13 @@ func (o *Orchestrator) ConfigAsString() string {
 		// sort by port number (retain ordering of chain flags)
 		sort.Slice(opSims, func(i, j int) bool { return opSims[i].Config().Port < opSims[j].Config().Port })
 		for _, opSim := range opSims {
-			fmt.Fprintf(&b, "  %s\n", opSim.String())
+			cfg := opSim.Config()
+			fmt.Fprintf(&b, "\n")
+			fmt.Fprintf(&b, "  * Name: %s  ChainID: %d  RPC: %s  LogPath: %s\n", cfg.Name, cfg.ChainID, opSim.Endpoint(), opSim.LogPath())
+			fmt.Fprintf(&b, "    L1 Contracts:\n")
+			fmt.Fprintf(&b, "     - OptimismPortal:         %s\n", cfg.L2Config.L1Addresses.OptimismPortalProxy)
+			fmt.Fprintf(&b, "     - L1CrossDomainMessenger: %s\n", cfg.L2Config.L1Addresses.L1CrossDomainMessengerProxy)
+			fmt.Fprintf(&b, "     - L1StandardBridge:       %s\n", cfg.L2Config.L1Addresses.L1StandardBridgeProxy)
 		}
 	}
 

--- a/supersim.go
+++ b/supersim.go
@@ -84,10 +84,11 @@ func (s *Supersim) Stopped() bool {
 
 func (s *Supersim) ConfigAsString() string {
 	var b strings.Builder
-	fmt.Fprint(&b, config.DefaultSecretsConfigAsString())
+	fmt.Fprintln(&b, config.DefaultSecretsConfigAsString())
 
-	fmt.Fprintf(&b, "\nOrchestrator Config:\n")
-	fmt.Fprint(&b, s.Orchestrator.ConfigAsString())
+	fmt.Fprintln(&b, "Orchestrator Config")
+	fmt.Fprintln(&b, "-----------------------")
+	fmt.Fprintln(&b, s.Orchestrator.ConfigAsString())
 
 	return b.String()
 }


### PR DESCRIPTION
Improve logging (spit out contract addresses). Code cleanup around this

```
Available Accounts
-----------------------
(0): 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
(1): 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
...

Private Keys
-----------------------
(0): 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
(1): 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
...

Orchestrator Config
-----------------------
L1: Name: Local  ChainID: 900  RPC: http://127.0.0.1:8545  LogPath: /var/folders/y6/bkjdghqx1sn_3ypk1n0zy3040000gn/T/anvil-chain-900-4142322133

L2s: Predeploy Contracts Spec ( https://specs.optimism.io/protocol/predeploys.html )

  * Name: OPChainA  ChainID: 901  RPC: http://127.0.0.1:9545  LogPath: /var/folders/y6/bkjdghqx1sn_3ypk1n0zy3040000gn/T/anvil-chain-901-3668226930
    L1 Contracts:
     - OptimismPortal:         0xF5fe61a258CeBb54CCe428F76cdeD04Cbc12F53d
     - L1CrossDomainMessenger: 0xe5bda89cd85cE0DfB80E053281cA070D65B738e6
     - L1StandardBridge:       0xa01ae68902e205B420FD164435F299E07b0C778b

  * Name: OPChainB  ChainID: 902  RPC: http://127.0.0.1:9546  LogPath: /var/folders/y6/bkjdghqx1sn_3ypk1n0zy3040000gn/T/anvil-chain-902-927231685
    L1 Contracts:
     - OptimismPortal:         0xdfC9DEAbEEbDaa7620C71e2E76AEda32919DE5f2
     - L1CrossDomainMessenger: 0xCB9768921831677Ae15cE4B64A10B94F49cD88E2
     - L1StandardBridge:       0x2D8543c236a4d626f54B51Fa8bc229a257C5143E
```

opsim client fixes