### PR TITLE
ci: setup homebrew releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,14 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   goreleaser:
+    if: github.repository == 'ethereum-optimism/supersim'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,3 +30,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_REPO_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_REPO_OPTIBOT_PAT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,3 +29,13 @@ archives:
         format: zip
 changelog:
   disable: true
+
+brews:
+  - name: supersim
+    directory: Formula
+    homepage: "https://github.com/ethereum-optimism/supersim"
+    description: "Supersim is a local dev environment for the Superchain"
+    repository:
+      owner: ethereum-optimism
+      name: homebrew-tap
+      token: "{{ .Env.TAP_REPO_GITHUB_TOKEN }}"


### PR DESCRIPTION
Pushes new releases as formulas to https://github.com/ethereum-optimism/homebrew-tap