### PR TITLE
fix: remove temp file on shutdown, allow specifying log dir

### DIFF
--- a/config/chain.go
+++ b/config/chain.go
@@ -57,6 +57,9 @@ type ChainConfig struct {
 
 	// Optional
 	StartingTimestamp uint64
+
+	// Optional
+	LogsDirectory string
 }
 
 type NetworkConfig struct {
@@ -90,7 +93,7 @@ type Chain interface {
 	Stop(ctx context.Context) error
 }
 
-func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {
+func GetDefaultNetworkConfig(startingTimestamp uint64, logsDirectory string) NetworkConfig {
 	return NetworkConfig{
 		// Enabled by default as it is included in genesis
 		InteropEnabled: true,
@@ -101,6 +104,7 @@ func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {
 			SecretsConfig:     DefaultSecretsConfig,
 			GenesisJSON:       genesis.GeneratedGenesisDeployment.L1.GenesisJSON,
 			StartingTimestamp: startingTimestamp,
+			LogsDirectory:     logsDirectory,
 		},
 		L2Configs: []ChainConfig{
 			{
@@ -114,6 +118,7 @@ func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {
 					DependencySet: []uint64{genesis.GeneratedGenesisDeployment.L2s[1].ChainID},
 				},
 				StartingTimestamp: startingTimestamp,
+				LogsDirectory:     logsDirectory,
 			},
 			{
 				Name:          "OPChainB",
@@ -126,6 +131,7 @@ func GetDefaultNetworkConfig(startingTimestamp uint64) NetworkConfig {
 					DependencySet: []uint64{genesis.GeneratedGenesisDeployment.L2s[0].ChainID},
 				},
 				StartingTimestamp: startingTimestamp,
+				LogsDirectory:     logsDirectory,
 			},
 		},
 	}

--- a/config/cli.go
+++ b/config/cli.go
@@ -21,6 +21,8 @@ const (
 	NetworkFlagName        = "network"
 	L2StartingPortFlagName = "l2.starting.port"
 
+	LogsDirectoryFlagName = "logs.directory"
+
 	InteropEnabledFlagName   = "interop.enabled"
 	InteropAutoRelayFlagName = "interop.autorelay"
 )
@@ -43,7 +45,13 @@ func BaseCLIFlags(envPrefix string) []cli.Flag {
 			Name:    InteropAutoRelayFlagName,
 			Value:   false,
 			Usage:   "Automatically relay messages sent to the L2ToL2CrossDomainMessenger using account 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "AUTORELAY"),
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_AUTORELAY"),
+		},
+		&cli.StringFlag{
+			Name:    LogsDirectoryFlagName,
+			Usage:   "Directory to store logs",
+			Value:   "",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "LOGS_DIRECTORY"),
 		},
 	}
 }
@@ -93,6 +101,8 @@ type CLIConfig struct {
 
 	InteropAutoRelay bool
 
+	LogsDirectory string
+
 	ForkConfig *ForkCLIConfig
 }
 
@@ -102,6 +112,8 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
 
 		InteropAutoRelay: ctx.Bool(InteropAutoRelayFlagName),
+
+		LogsDirectory: ctx.String(LogsDirectoryFlagName),
 	}
 
 	if ctx.Command.Name == ForkCommandName {

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -21,7 +21,7 @@ type TestSuite struct {
 }
 
 func createTestSuite(t *testing.T) *TestSuite {
-	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()))
+	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()), "")
 	testlog := testlog.Logger(t, log.LevelInfo)
 
 	ctx, closeApp := context.WithCancelCause(context.Background())

--- a/supersim.go
+++ b/supersim.go
@@ -24,7 +24,7 @@ type Supersim struct {
 }
 
 func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseFunc, cliConfig *config.CLIConfig) (*Supersim, error) {
-	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()))
+	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()), cliConfig.LogsDirectory)
 
 	// If Forking, override the network config with the generated fork config
 	if cliConfig.ForkConfig != nil {


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/supersim/issues/132

- deletes temp files for
  - logs
  - genesis.json: the genesis.json files can get very large and fill up disk space
- `--logs.directory` allows specifying log directory - if specified it won't be deleted by default