### PR TITLE
Improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Git metafiles
+.git*
+
+# Editor metafiles
+.vscode
+
+# Docker metafiles
+Dockerfile
+
+# Project metafiles
+docs
+examples
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,15 @@
 # by specifying BASE_IMAGE build argument
 ARG BASE_IMAGE=golang:1.22
 
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 # 
-# This stage builds the foundry binaries
+#           This stage builds the foundry binaries
 # 
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 FROM $BASE_IMAGE AS foundry
 
 # Make sure foundryup is available
@@ -19,9 +25,15 @@ RUN \
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN foundryup
 
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 # 
-# This stage builds the project
+#                 This stage builds the project
 # 
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 FROM $BASE_IMAGE AS builder
 
 WORKDIR /app
@@ -31,9 +43,15 @@ COPY . .
 RUN go mod tidy
 RUN go build -o supersim cmd/main.go
 
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 # 
-# This stage exposes the supersim binary
+#            This stage exposes the supersim binary
 # 
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 FROM $BASE_IMAGE AS runner
 
 # Add foundry & supersim directories to the system PATH
@@ -47,7 +65,7 @@ COPY --from=builder /app/supersim /root/.supersim/bin/supersim
 # Get the anvil binary
 COPY --from=foundry /root/.foundry/bin/anvil /root/.foundry/bin/anvil
 
-# Make sure the foundry binaries exist
+# Make sure the required binaries exist
 RUN anvil --version
 RUN supersim --help
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ARG BASE_IMAGE=golang:1.22
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-# 
+#
 #           This stage builds the foundry binaries
-# 
+#
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
@@ -28,9 +28,9 @@ RUN foundryup
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-# 
+#
 #                 This stage builds the project
-# 
+#
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
@@ -46,9 +46,9 @@ RUN go build -o supersim cmd/main.go
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-# 
+#
 #            This stage exposes the supersim binary
-# 
+#
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
@@ -69,4 +69,9 @@ COPY --from=foundry /root/.foundry/bin/anvil /root/.foundry/bin/anvil
 RUN anvil --version
 RUN supersim --help
 
-CMD ["supersim"]
+# We'll use supersim as the entrypoint to our image
+# 
+# This allows the consumers to pass CLI options as the command to docker run:
+# 
+# docker run supersim --help
+ENTRYPOINT [ "supersim" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,54 @@
-FROM golang:1.22
+# The base image for the supersim image can be modified
+# by specifying BASE_IMAGE build argument
+ARG BASE_IMAGE=golang:1.22
 
-RUN apt-get update && apt-get install -y curl git
+# 
+# This stage builds the foundry binaries
+# 
+FROM $BASE_IMAGE AS foundry
 
-WORKDIR /app
-
-RUN curl -L https://foundry.paradigm.xyz | bash
-
+# Make sure foundryup is available
 ENV PATH="/root/.foundry/bin:${PATH}"
 
+# Install required system packages
+RUN \
+    apt-get update && \
+    apt-get install -y curl git
+
+# Install foundry
+RUN curl -L https://foundry.paradigm.xyz | bash
 RUN foundryup
+
+# 
+# This stage builds the project
+# 
+FROM $BASE_IMAGE AS builder
+
+WORKDIR /app
 
 COPY . .
 
 RUN go mod tidy
-
 RUN go build -o supersim cmd/main.go
 
-CMD ["./supersim"]
+# 
+# This stage exposes the supersim binary
+# 
+FROM $BASE_IMAGE AS runner
+
+# Add foundry & supersim directories to the system PATH
+ENV PATH="/root/.foundry/bin:/root/.supersim/bin:${PATH}"
+
+WORKDIR /app
+
+# Get the supersim binary from the builder
+COPY --from=builder /app/supersim /root/.supersim/bin/supersim
+
+# Get the anvil binary
+COPY --from=foundry /root/.foundry/bin/anvil /root/.foundry/bin/anvil
+
+# Make sure the foundry binaries exist
+RUN anvil --version
+RUN supersim --help
+
+CMD ["supersim"]


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Leverage multi-stage build in the `Dockerfile` to speed up the docker build by enabling the individual stages to run in parallel
  - Add `foundry` stage that downloads `foundry`
  - Add `builder` stage that builds the project
  - Add `runner` stage that combines the binaries from the two other stages
- Parameterize the base image using the `BASE_IMAGE` build argument
- Used `ENTRYPOINT` instead of `CMD`. This allows user to simply `docker run` the image to execute `supersim` with no arguments or, if they need to, pass `supersim` arguments directly to `docker run`
- Added `.dockerignore` to exclude metafiles & docs from being copied to the builder image

There are several more improvements possible (e.g. `go` is not really required in the `runner` stage) but have not been added for the sake of brevity

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

- Add `RUN` commands to the `Dockerfile` to ensure that the required binaries exist

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
