### PR TITLE
Add docker image tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
-          outputs: type=docker,supersim:dev
+          outputs: type=docker,optimism/supersim:dev
           cache-from: type=gha,scope=build-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,8 +117,10 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v6
         with:
-          tags: optimism/supersim:dev
           platforms: ${{ matrix.platform }}
+          outputs: type=docker,supersim:dev
+          cache-from: type=gha,scope=build-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
 
       - name: Smoke test docker image
-        run: docker run optimism/supersim:dev --help
+        run: docker run supersim:dev --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
-          outputs: type=docker,optimism/supersim:dev
+          outputs: type=docker,name=supersim:dev
           cache-from: type=gha,scope=build-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           tags: optimism/supersim:dev
-          platform: ${{ matrix.platform }}
+          platforms: ${{ matrix.platform }}
 
       - name: Smoke test docker image
         run: docker run supersim:dev --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,8 +108,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build docker image
-        run: docker build --tag supersim:dev --platform ${{ matrix.platform }} .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          tags: optimism/supersim:dev
+          platform: ${{ matrix.platform }}
 
       - name: Smoke test docker image
         run: docker run supersim:dev --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           just test-contracts
         id: test
-  
+
   go-lint:
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup
         uses: ./.github/actions/setup
 
@@ -93,3 +93,23 @@ jobs:
         env:
           SUPERSIM_RPC_URL_OP: ${{ vars.SUPERSIM_RPC_URL_OP }}
           SUPERSIM_RPC_URL_BASE: ${{ vars.SUPERSIM_RPC_URL_BASE }}
+
+  docker-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build docker image
+        run: docker build --tag supersim:dev --platform ${{ matrix.platform }} .
+
+      - name: Smoke test docker image
+        run: docker run supersim:dev --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,4 +121,4 @@ jobs:
           platforms: ${{ matrix.platform }}
 
       - name: Smoke test docker image
-        run: docker run supersim:dev --help
+        run: docker run optimism/supersim:dev --help


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Adding smoke tests for `linux/amd64` and `linux/arm64` images to the CI pipeline. These tests check that the `Dockerfile` can be built as well as that the `supersim` executable runs fine when the image is run

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

- Yesssss

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
