### PR TITLE
CI pins go version to whats in go.mod

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '^1.22'
+        go-version: '1.22.3'
 
     - name: Setup Just
       uses: extractions/setup-just@v1


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

I noticed that `golangci-lint` is [failing to install ](https://github.com/ethereum-optimism/supersim/actions/runs/11408059484/job/31745440552#step:3:38) on a couple of PRs now when we're pulling in go `1.23` so this PR just pins to the go version in our go.mod file to avoid this. We'll most likely need to bump our `golangci-lint` version once we want to update our go version
