### PR TITLE
fix(test): fix issue causing required field 'gasPrice' in transaction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,4 +102,4 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.0-rc.1
+replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101411.0-rc.1 h1:xRheNbOM+Js9a+dqVt5LmBqQK8L5IyHKU8FfI4Cy9qw=
-github.com/ethereum-optimism/op-geth v1.101411.0-rc.1/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
+github.com/ethereum-optimism/op-geth v1.101411.0 h1:K5QDCehYwOHSNAwI5SKpi/WhpnLophjbePtOo4qHTVc=
+github.com/ethereum-optimism/op-geth v1.101411.0/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
 github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8 h1:bhG/9dttuyOPZZUhMb3e5zApDunSAE5a8sy42P/V7sw=
 github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8/go.mod h1:5vH0W+a+76TjhxA//o8jr5d/zouHQaFtspVu0N2jumk=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20241002103526-9083af857790 h1:yZlEBCdD0izqzTvmhET1roNSzMfXL50DhL+dALYlnXk=

--- a/interop/indexer.go
+++ b/interop/indexer.go
@@ -178,16 +178,16 @@ func (i *L2ToL2MessageIndexer) createSubscription(key string, messageChan chan<-
 }
 
 func getIdentifier(ctx context.Context, backend ethereum.ChainReader, chainID uint64, log *types.Log) (*bindings.ICrossL2InboxIdentifier, error) {
-	block, err := backend.BlockByNumber(ctx, big.NewInt(int64(log.BlockNumber)))
+	blockHeader, err := backend.HeaderByNumber(ctx, big.NewInt(int64(log.BlockNumber)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block: %w", err)
 	}
 
 	return &bindings.ICrossL2InboxIdentifier{
 		Origin:      log.Address,
-		BlockNumber: block.Number(),
+		BlockNumber: blockHeader.Number,
 		LogIndex:    big.NewInt(int64(log.Index)),
-		Timestamp:   big.NewInt(int64(block.Time())),
+		Timestamp:   big.NewInt(int64(blockHeader.Time)),
 		ChainId:     big.NewInt(int64(chainID)),
 	}, nil
 }

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -391,12 +391,12 @@ func (opSim *OpSimulator) checkInteropInvariants(ctx context.Context, tx *types.
 			}
 
 			sourceClient := sourceChain.EthClient()
-			identifierBlock, err := sourceClient.BlockByNumber(ctx, identifier.BlockNumber)
+			identifierBlockHeader, err := sourceClient.HeaderByNumber(ctx, identifier.BlockNumber)
 			if err != nil {
 				return fmt.Errorf("failed to fetch executing message block: %w", err)
 			}
 
-			if identifier.Timestamp.Cmp(new(big.Int).SetUint64(identifierBlock.Time())) != 0 {
+			if identifier.Timestamp.Cmp(new(big.Int).SetUint64(identifierBlockHeader.Time)) != 0 {
 				return fmt.Errorf("executing message identifier does not match block timestamp: %w", err)
 			}
 

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -437,14 +437,14 @@ func TestBatchJsonRpcRequestErrorHandling(t *testing.T) {
 	// Create a bad executing message that will throw an error using CrossL2Inbox
 	executeMessageNonce, err := testSuite.DestEthClient.PendingNonceAt(context.Background(), fromAddress)
 	require.NoError(t, err)
-	initiatingMessageBlock, err := testSuite.SourceEthClient.BlockByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
 	require.NoError(t, err)
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
 	identifier := bindings.ICrossL2InboxIdentifier{
 		Origin:      origin,
 		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
 		LogIndex:    big.NewInt(0),
-		Timestamp:   new(big.Int).Sub(new(big.Int).SetUint64(initiatingMessageBlock.Time()), big.NewInt(1)),
+		Timestamp:   new(big.Int).Sub(new(big.Int).SetUint64(initiatingMessageBlockHeader.Time), big.NewInt(1)),
 		ChainId:     testSuite.SourceChainID,
 	}
 	executeMessageCallData, err := bindings.CrossL2InboxParsedABI.Pack("executeMessage", identifier, fromAddress, initiatingMessageLog.Data)
@@ -497,14 +497,14 @@ func TestInteropInvariantCheckSucceeds(t *testing.T) {
 
 	l2tol2CDM, err := bindings.NewL2ToL2CrossDomainMessengerTransactor(predeploys.L2toL2CrossDomainMessengerAddr, testSuite.DestEthClient)
 	require.NoError(t, err)
-	initiatingMessageBlock, err := testSuite.SourceEthClient.BlockByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
 	require.NoError(t, err)
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
 	identifier := bindings.ICrossL2InboxIdentifier{
 		Origin:      origin,
 		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
 		LogIndex:    big.NewInt(0),
-		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlock.Time()),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
 		ChainId:     testSuite.SourceChainID,
 	}
 	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
@@ -551,7 +551,7 @@ func TestInteropInvariantCheckFailsBadLogIndex(t *testing.T) {
 
 	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.DestEthClient)
 	require.NoError(t, err)
-	initiatingMessageBlock, err := testSuite.SourceEthClient.BlockByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
 	require.NoError(t, err)
 
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
@@ -559,7 +559,7 @@ func TestInteropInvariantCheckFailsBadLogIndex(t *testing.T) {
 		Origin:      origin,
 		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
 		LogIndex:    big.NewInt(1), // Wrong index
-		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlock.Time()),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
 		ChainId:     testSuite.SourceChainID,
 	}
 	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
@@ -603,14 +603,14 @@ func TestInteropInvariantCheckBadBlockNumber(t *testing.T) {
 	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.DestEthClient)
 	require.NoError(t, err)
 	wrongBlockNumber := new(big.Int).Add(initiatingMessageTxReceipt.BlockNumber, big.NewInt(1))
-	wrongMessageBlock, err := testSuite.SourceEthClient.BlockByNumber(context.Background(), wrongBlockNumber)
+	wrongMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), wrongBlockNumber)
 	require.NoError(t, err)
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
 	identifier := bindings.ICrossL2InboxIdentifier{
 		Origin:      origin,
 		BlockNumber: wrongBlockNumber,
 		LogIndex:    big.NewInt(0),
-		Timestamp:   new(big.Int).SetUint64(wrongMessageBlock.Time()),
+		Timestamp:   new(big.Int).SetUint64(wrongMessageBlockHeader.Time),
 		ChainId:     testSuite.SourceChainID,
 	}
 	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
@@ -653,14 +653,14 @@ func TestInteropInvariantCheckBadBlockTimestamp(t *testing.T) {
 
 	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.DestEthClient)
 	require.NoError(t, err)
-	initiatingMessageBlock, err := testSuite.SourceEthClient.BlockByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
 	require.NoError(t, err)
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
 	identifier := bindings.ICrossL2InboxIdentifier{
 		Origin:      origin,
 		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
 		LogIndex:    big.NewInt(0),
-		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlock.Time() + 1),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time + 1),
 		ChainId:     testSuite.SourceChainID,
 	}
 	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
@@ -703,14 +703,14 @@ func TestForkedInteropInvariantCheckSucceeds(t *testing.T) {
 
 	l2tol2CDM, err := bindings.NewL2ToL2CrossDomainMessengerTransactor(predeploys.L2toL2CrossDomainMessengerAddr, testSuite.DestEthClient)
 	require.NoError(t, err)
-	initiatingMessageBlock, err := testSuite.SourceEthClient.BlockByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
 	require.NoError(t, err)
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
 	identifier := bindings.ICrossL2InboxIdentifier{
 		Origin:      origin,
 		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
 		LogIndex:    big.NewInt(0),
-		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlock.Time()),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
 		ChainId:     testSuite.SourceChainID,
 	}
 	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)


### PR DESCRIPTION
## problem

`ethClient.getBlockByNumber` (source: [here](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber)) by default passes "true" to "transaction_detail_flag", which causes it to return an array of tx when fetching the block.

Anvil returns a block like below. Notice how there's no tx type in the transaction object, which is a deposit tx. 
1. since the tx type is missing
2. geth library assumes it's a legacy tx
3. attempts to unmarshal the tx object
4. throws error because it can't find `gasPrice`, which is a required param.

this only happens occasionally in tests IFF the send message happens in same block as the deposit tx that sets the dependency set.

```
{
  "hash": "0xdb27f4591ceaad75452baece037724d6fb3c915e64c1ce27862381a27b337a44",
  "parentHash": "0x6a32e9da30660bfb3363e3fec252754bcaba4359b3221dfe898815f892153bae",
  "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  "miner": "0x0000000000000000000000000000000000000000",
  "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "transactionsRoot": "0x0ee2379e9c76399e9943d6ce72d1088e18197d18676d5ba97295253191fde42e",
  "receiptsRoot": "0x95c8d0636c2a849b5e03f82f2b1d5fb638ea4f19c646e57a6787a8a7d3a10759",
  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000010000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080020000020000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000100000000000000000",
  "difficulty": "0x0",
  "number": "0x7918cea",
  "gasLimit": "0x1c9c380",
  "gasUsed": "0x1761e",
  "timestamp": "0x6716f38e",
  "totalDifficulty": "0xc8b84ed",
  "extraData": "0x",
  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "nonce": "0x0000000000000000",
  "baseFeePerGas": "0x1359f",
  "blobGasUsed": "0x0",
  "excessBlobGas": "0x0",
  "uncles": [],
  "transactions": [
    {
      "hash": "0xec809245dea3ac31a9b9f36c6abf0f1b940d2c08fbbae921691541f805d2af59",
      "nonce": "0x0",
      "blockHash": "0xdb27f4591ceaad75452baece037724d6fb3c915e64c1ce27862381a27b337a44",
      "blockNumber": "0x7918cea",
      "transactionIndex": "0x0",
      "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
      "to": "0x4200000000000000000000000000000000000015",
      "value": "0x0",
      "gas": "0xf4240",
      "input": "0xc00121630000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000002105"
    }
  ],
  "size": "0x2e9"
}
```

## solution
use HeaderByNumber. this doesn't automatically set the return transaction details flag to true. This should alleviate the flakes on CI (but not all of it)

created another issue to investigate if this is just anvil or common behavior https://github.com/ethereum-optimism/supersim/issues/217