### PR TITLE
fix(adminSrv): configurable port

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 
@@ -11,22 +12,23 @@ import (
 )
 
 type AdminServer struct {
+	log log.Logger
+
 	srv    *http.Server
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	log log.Logger
+	port uint64
 }
 
-func NewAdminServer(log log.Logger) *AdminServer {
-	return &AdminServer{log: log}
+func NewAdminServer(log log.Logger, port uint64) *AdminServer {
+	return &AdminServer{log: log, port: port}
 }
 
 func (s *AdminServer) Start(ctx context.Context) error {
 	router := setupRouter()
-
 	s.srv = &http.Server{
-		Addr:    ":8420",
+		Addr:    fmt.Sprintf(":%d", s.port),
 		Handler: router,
 	}
 
@@ -56,6 +58,10 @@ func (s *AdminServer) Stop(ctx context.Context) error {
 	}
 	s.wg.Wait()
 	return nil
+}
+
+func (s *AdminServer) Endpoint() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", s.port)
 }
 
 func setupRouter() *gin.Engine {

--- a/config/cli.go
+++ b/config/cli.go
@@ -14,6 +14,8 @@ import (
 const (
 	ForkCommandName = "fork"
 
+	AdminPortFlagName = "admin.port"
+
 	L1ForkHeightFlagName = "l1.fork.height"
 	L1PortFlagName       = "l1.port"
 
@@ -29,6 +31,12 @@ const (
 
 func BaseCLIFlags(envPrefix string) []cli.Flag {
 	return []cli.Flag{
+		&cli.Uint64Flag{
+			Name:    AdminPortFlagName,
+			Usage:   "Listening port for the admin server",
+			Value:   8420,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "ADMIN_PORT"),
+		},
 		&cli.Uint64Flag{
 			Name:    L1PortFlagName,
 			Usage:   "Listening port for the L1 instance. `0` binds to any available port",
@@ -96,6 +104,8 @@ type ForkCLIConfig struct {
 }
 
 type CLIConfig struct {
+	AdminPort uint64
+
 	L1Port         uint64
 	L2StartingPort uint64
 
@@ -108,6 +118,8 @@ type CLIConfig struct {
 
 func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 	cfg := &CLIConfig{
+		AdminPort: ctx.Uint64(AdminPortFlagName),
+
 		L1Port:         ctx.Uint64(L1PortFlagName),
 		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
 


### PR DESCRIPTION
Admin port needs to be configurable. Fixes CI flakes. The cli flag default can be 8420

- Leave the orchestrator package to detail with chain orchestration and the supersim struct holding reference to the admin server
