### PR TITLE
feat(admin): added getL1Addresses(chainId) rpc support 

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -131,7 +131,7 @@ func (m *RPCMethods) GetConfig(args *struct{}) *config.NetworkConfig {
 func (m *RPCMethods) GetL1Addresses(args *uint64) *map[string]string {
 	chain := filterByChainID(m.NetworkConfig.L2Configs, *args)
 	if chain == nil {
-		m.Log.Debug("chain not found")
+		m.Log.Error("chain not found", "chainID", *args)
 		return nil
 	}
 

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -36,7 +36,7 @@ func NewAdminServer(log log.Logger, port uint64, networkConfig *config.NetworkCo
 }
 
 func (s *AdminServer) Start(ctx context.Context) error {
-	router := setupRouter(s)
+	router := s.setupRouter()
 
 	s.srv = &http.Server{Handler: router}
 
@@ -96,12 +96,11 @@ func filterByChainID(chains []config.ChainConfig, chainId uint64) *config.ChainC
 	return nil
 }
 
-func setupRouter(s *AdminServer) *gin.Engine {
+func (s *AdminServer) setupRouter() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 	router.Use(gin.Recovery())
 
-	// Set up RPC server
 	rpcServer := rpc.NewServer()
 	rpcMethods := &RPCMethods{
 		Log:           s.log,

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -14,8 +14,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var networkConfig *config.NetworkConfig
-
 type AdminServer struct {
 	log log.Logger
 
@@ -23,17 +21,19 @@ type AdminServer struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	rpcServer *rpc.Server // New field for the RPC server
+	rpcServer     *rpc.Server // New field for the RPC server
+	networkConfig *config.NetworkConfig
 
 	port uint64
 }
 
 type RPCMethods struct {
-	Log log.Logger
+	Log           log.Logger
+	networkConfig *config.NetworkConfig
 }
 
-func NewAdminServer(log log.Logger, port uint64) *AdminServer {
-	return &AdminServer{log: log, port: port}
+func NewAdminServer(log log.Logger, port uint64, networkConfig *config.NetworkConfig) *AdminServer {
+	return &AdminServer{log: log, port: port, networkConfig: networkConfig}
 }
 
 func (s *AdminServer) Start(ctx context.Context) error {
@@ -52,7 +52,7 @@ func (s *AdminServer) Start(ctx context.Context) error {
 
 	// Set up RPC server
 	rpcServer := rpc.NewServer()
-	rpcMethods := &RPCMethods{Log: s.log}
+	rpcMethods := &RPCMethods{Log: s.log, networkConfig: s.networkConfig}
 
 	if err := rpcServer.RegisterName("Admin", rpcMethods); err != nil {
 		return fmt.Errorf("failed to register RPC methods: %w", err)

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -6,17 +6,21 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/supersim/config"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAdminServerBasicFunctionality(t *testing.T) {
+	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()), "")
 	testlog := testlog.Logger(t, log.LevelInfo)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adminServer := NewAdminServer(testlog, 0)
+	adminServer := NewAdminServer(testlog, 0, &networkConfig)
 	t.Cleanup(func() { cancel() })
 
 	require.NoError(t, adminServer.Start(ctx))
@@ -38,4 +42,30 @@ func TestAdminServerBasicFunctionality(t *testing.T) {
 		resp.Body.Close()
 	}
 	require.Error(t, err)
+}
+
+func TestGetL1AddressesRPC(t *testing.T) {
+	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()), "")
+	testlog := testlog.Logger(t, log.LevelInfo)
+	server := NewAdminServer(testlog, 0, &networkConfig)
+	defer server.Stop(context.Background())
+
+	// Start the server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go server.Start(ctx)
+	time.Sleep(1 * time.Second) // Allow time for the server to start
+
+	// Dial the RPC server
+	client, err := rpc.Dial(server.Endpoint())
+	require.NoError(t, err)
+
+	var addresses map[string]string
+	chainID := uint64(902)
+	err = client.CallContext(context.Background(), &addresses, "admin_getL1Addresses", chainID)
+
+	require.NoError(t, err)
+
+	require.Equal(t, "0xeCA0f912b4bd255f3851951caE5775CC9400aA3B", addresses["L2CrossDomainMessenger"])
+	require.Equal(t, "0x67B2aB287a32bB9ACe84F6a5A30A62597b10AdE9", addresses["L2StandardBridge"])
 }

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/supersim/config"
+	"github.com/ethereum-optimism/supersim/testutils"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,25 +49,45 @@ func TestAdminServerBasicFunctionality(t *testing.T) {
 func TestGetL1AddressesRPC(t *testing.T) {
 	networkConfig := config.GetDefaultNetworkConfig(uint64(time.Now().Unix()), "")
 	testlog := testlog.Logger(t, log.LevelInfo)
-	server := NewAdminServer(testlog, 0, &networkConfig)
-	defer server.Stop(context.Background())
 
-	// Start the server
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go server.Start(ctx)
-	time.Sleep(1 * time.Second) // Allow time for the server to start
+	adminServer := NewAdminServer(testlog, 0, &networkConfig)
+	t.Cleanup(func() { cancel() })
 
-	// Dial the RPC server
-	client, err := rpc.Dial(server.Endpoint())
-	require.NoError(t, err)
+	require.NoError(t, adminServer.Start(ctx))
 
-	var addresses map[string]string
-	chainID := uint64(902)
-	err = client.CallContext(context.Background(), &addresses, "admin_getL1Addresses", chainID)
+	waitErr := testutils.WaitForWithTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		// Dial the RPC server
+		client, err := rpc.Dial(adminServer.Endpoint())
+		require.NoError(t, err)
 
-	require.NoError(t, err)
+		var addresses map[string]string
+		chainID := uint64(902)
+		err = client.CallContext(context.Background(), &addresses, "admin_getL1Addresses", chainID)
 
-	require.Equal(t, "0xeCA0f912b4bd255f3851951caE5775CC9400aA3B", addresses["L2CrossDomainMessenger"])
-	require.Equal(t, "0x67B2aB287a32bB9ACe84F6a5A30A62597b10AdE9", addresses["L2StandardBridge"])
+		require.NoError(t, err)
+
+		expectedAddresses := map[string]string{
+			"AddressManager":                    "0x90D0B458313d3A207ccc688370eE76B75200EadA",
+			"L1CrossDomainMessengerProxy":       "0xeCA0f912b4bd255f3851951caE5775CC9400aA3B",
+			"L1ERC721BridgeProxy":               "0xdC0917C61A4CD589B29b6464257d564C0abeBB2a",
+			"L1StandardBridgeProxy":             "0x67B2aB287a32bB9ACe84F6a5A30A62597b10AdE9",
+			"L2OutputOracleProxy":               "0x0000000000000000000000000000000000000000",
+			"OptimismMintableERC20FactoryProxy": "0xd4E933aa1f37A755135d7623488a383f8208CC7c",
+			"OptimismPortalProxy":               "0x35e67BC631C327b60C6A39Cff6b03a8adBB19c2D",
+			"ProxyAdmin":                        "0x0000000000000000000000000000000000000000",
+			"SuperchainConfig":                  "0x0000000000000000000000000000000000000000",
+			"SystemConfigProxy":                 "0xFb295Aa436F23BE2Bd17678Adf1232bdec02FED1",
+		}
+
+		for key, expectedValue := range expectedAddresses {
+			if addresses[key] != expectedValue {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	assert.NoError(t, waitErr)
 }

--- a/supersim.go
+++ b/supersim.go
@@ -65,6 +65,7 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 		return nil, fmt.Errorf("failed to create orchestrator")
 	}
 
+	// passing network config to admin server
 	adminServer := admin.NewAdminServer(log, cliConfig.AdminPort, &networkConfig)
 
 	return &Supersim{log, cliConfig, &networkConfig, o, adminServer}, nil
@@ -109,7 +110,6 @@ func (s *Supersim) ConfigAsString() string {
 
 	fmt.Fprintln(&b, "Supersim Config")
 	fmt.Fprintln(&b, "-----------------------")
-	fmt.Fprintf(&b, "Admin Server: %s\n\n", s.adminServer.Endpoint())
 	fmt.Fprintf(&b, s.adminServer.ConfigAsString())
 
 	fmt.Fprintln(&b, "Chain Configuration")

--- a/supersim.go
+++ b/supersim.go
@@ -72,9 +72,9 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 
 func (s *Supersim) Start(ctx context.Context) error {
 	s.log.Info("starting supersim")
-	// if err := s.Orchestrator.Start(ctx); err != nil {
-	// 	return fmt.Errorf("orchestrator failed to start: %w", err)
-	// }
+	if err := s.Orchestrator.Start(ctx); err != nil {
+		return fmt.Errorf("orchestrator failed to start: %w", err)
+	}
 	if err := s.adminServer.Start(ctx); err != nil {
 		return fmt.Errorf("admin server failed to start: %w", err)
 	}
@@ -87,9 +87,9 @@ func (s *Supersim) Start(ctx context.Context) error {
 func (s *Supersim) Stop(ctx context.Context) error {
 	var errs []error
 	s.log.Info("stopping supersim")
-	// if err := s.Orchestrator.Stop(ctx); err != nil {
-	// 	errs = append(errs, fmt.Errorf("orchestrator failed to stop: %w", err))
-	// }
+	if err := s.Orchestrator.Stop(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("orchestrator failed to stop: %w", err))
+	}
 	if err := s.adminServer.Stop(ctx); err != nil {
 		errs = append(errs, fmt.Errorf("admin server failed to stop: %w", err))
 	}

--- a/supersim.go
+++ b/supersim.go
@@ -65,15 +65,16 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 		return nil, fmt.Errorf("failed to create orchestrator")
 	}
 
-	adminServer := admin.NewAdminServer(log, cliConfig.AdminPort)
+	adminServer := admin.NewAdminServer(log, cliConfig.AdminPort, &networkConfig)
+
 	return &Supersim{log, cliConfig, &networkConfig, o, adminServer}, nil
 }
 
 func (s *Supersim) Start(ctx context.Context) error {
 	s.log.Info("starting supersim")
-	if err := s.Orchestrator.Start(ctx); err != nil {
-		return fmt.Errorf("orchestrator failed to start: %w", err)
-	}
+	// if err := s.Orchestrator.Start(ctx); err != nil {
+	// 	return fmt.Errorf("orchestrator failed to start: %w", err)
+	// }
 	if err := s.adminServer.Start(ctx); err != nil {
 		return fmt.Errorf("admin server failed to start: %w", err)
 	}
@@ -86,9 +87,9 @@ func (s *Supersim) Start(ctx context.Context) error {
 func (s *Supersim) Stop(ctx context.Context) error {
 	var errs []error
 	s.log.Info("stopping supersim")
-	if err := s.Orchestrator.Stop(ctx); err != nil {
-		errs = append(errs, fmt.Errorf("orchestrator failed to stop: %w", err))
-	}
+	// if err := s.Orchestrator.Stop(ctx); err != nil {
+	// 	errs = append(errs, fmt.Errorf("orchestrator failed to stop: %w", err))
+	// }
 	if err := s.adminServer.Stop(ctx); err != nil {
 		errs = append(errs, fmt.Errorf("admin server failed to stop: %w", err))
 	}
@@ -109,6 +110,7 @@ func (s *Supersim) ConfigAsString() string {
 	fmt.Fprintln(&b, "Supersim Config")
 	fmt.Fprintln(&b, "-----------------------")
 	fmt.Fprintf(&b, "Admin Server: %s\n\n", s.adminServer.Endpoint())
+	fmt.Fprintf(&b, s.adminServer.ConfigAsString())
 
 	fmt.Fprintln(&b, "Chain Configuration")
 	fmt.Fprintln(&b, "-----------------------")

--- a/supersim.go
+++ b/supersim.go
@@ -65,7 +65,6 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 		return nil, fmt.Errorf("failed to create orchestrator")
 	}
 
-	// passing network config to admin server
 	adminServer := admin.NewAdminServer(log, cliConfig.AdminPort, &networkConfig)
 
 	return &Supersim{log, cliConfig, &networkConfig, o, adminServer}, nil


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

added getL1Addresses(chainId) support with /getL1Addresses/:chainID, essentially letting devs check L1 address for a particular L2 chain via chain ID

**Additional context**
Just prints L1 address for particular L2 chain via chain ID

**Metadata**

- adds extra functionality requested in #204 

