### PR TITLE
✨ Adds interop delay option

### DIFF
--- a/config/chain.go
+++ b/config/chain.go
@@ -72,8 +72,9 @@ type NetworkConfig struct {
 
 	// Signaled higher up as a way to generally
 	// check if Interop is enabled
-	InteropEnabled   bool
-	InteropAutoRelay bool
+	InteropEnabled        bool
+	InteropAutoRelay      bool
+	InteropInclusionDelay bool
 }
 
 type Chain interface {

--- a/config/chain.go
+++ b/config/chain.go
@@ -72,9 +72,9 @@ type NetworkConfig struct {
 
 	// Signaled higher up as a way to generally
 	// check if Interop is enabled
-	InteropEnabled        bool
-	InteropAutoRelay      bool
-	InteropInclusionDelay bool
+	InteropEnabled   bool
+	InteropAutoRelay bool
+	InteropDelay     uint64
 }
 
 type Chain interface {

--- a/config/cli.go
+++ b/config/cli.go
@@ -72,6 +72,12 @@ func BaseCLIFlags(envPrefix string) []cli.Flag {
 			Value:   "",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "LOGS_DIRECTORY"),
 		},
+		&cli.Uint64Flag{
+			Name:    InteropDelayFlagName,
+			Value:   0, // enabled by default
+			Usage:   "Delay before relaying messages sent to the L2ToL2CrossDomainMessenger",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_DELAY"),
+		},
 	}
 }
 
@@ -103,12 +109,6 @@ func ForkCLIFlags(envPrefix string) []cli.Flag {
 			Usage:   "enable interop predeploy and functionality",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_ENABLED"),
 		},
-		&cli.BoolFlag{
-			Name:    InteropDelayFlagName,
-			Value:   false, // enabled by default
-			Usage:   "enable interop inclusion delay functionality",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_INCLUSION_DELAY"),
-		},
 	}
 }
 
@@ -118,7 +118,6 @@ type ForkCLIConfig struct {
 	Chains       []string
 
 	InteropEnabled bool
-	InteropDelay   uint64
 }
 
 type CLIConfig struct {
@@ -155,7 +154,6 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 			Chains:       ctx.StringSlice(ChainsFlagName),
 
 			InteropEnabled: ctx.Bool(InteropEnabledFlagName),
-			InteropDelay:   ctx.Uint64(InteropDelayFlagName),
 		}
 	}
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -26,8 +26,9 @@ const (
 
 	LogsDirectoryFlagName = "logs.directory"
 
-	InteropEnabledFlagName   = "interop.enabled"
-	InteropAutoRelayFlagName = "interop.autorelay"
+	InteropEnabledFlagName        = "interop.enabled"
+	InteropAutoRelayFlagName      = "interop.autorelay"
+	InteropInclusionDelayFlagName = "interop.inclusiondelay"
 )
 
 var documentationLinks = []struct {
@@ -102,6 +103,12 @@ func ForkCLIFlags(envPrefix string) []cli.Flag {
 			Usage:   "enable interop predeploy and functionality",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_ENABLED"),
 		},
+		&cli.BoolFlag{
+			Name:    InteropInclusionDelayFlagName,
+			Value:   false, // enabled by default
+			Usage:   "enable interop inclusion delay functionality",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_INCLUSION_DELAY"),
+		},
 	}
 }
 
@@ -110,7 +117,8 @@ type ForkCLIConfig struct {
 	Network      string
 	Chains       []string
 
-	InteropEnabled bool
+	InteropEnabled        bool
+	InteropInclusionDelay bool
 }
 
 type CLIConfig struct {
@@ -119,7 +127,8 @@ type CLIConfig struct {
 	L1Port         uint64
 	L2StartingPort uint64
 
-	InteropAutoRelay bool
+	InteropAutoRelay      bool
+	InteropInclusionDelay bool
 
 	LogsDirectory string
 
@@ -133,7 +142,8 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 		L1Port:         ctx.Uint64(L1PortFlagName),
 		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
 
-		InteropAutoRelay: ctx.Bool(InteropAutoRelayFlagName),
+		InteropAutoRelay:      ctx.Bool(InteropAutoRelayFlagName),
+		InteropInclusionDelay: ctx.Bool(InteropInclusionDelayFlagName),
 
 		LogsDirectory: ctx.String(LogsDirectoryFlagName),
 	}
@@ -144,7 +154,8 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 			Network:      ctx.String(NetworkFlagName),
 			Chains:       ctx.StringSlice(ChainsFlagName),
 
-			InteropEnabled: ctx.Bool(InteropEnabledFlagName),
+			InteropEnabled:        ctx.Bool(InteropEnabledFlagName),
+			InteropInclusionDelay: ctx.Bool(InteropInclusionDelayFlagName),
 		}
 	}
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -26,9 +26,9 @@ const (
 
 	LogsDirectoryFlagName = "logs.directory"
 
-	InteropEnabledFlagName        = "interop.enabled"
-	InteropAutoRelayFlagName      = "interop.autorelay"
-	InteropInclusionDelayFlagName = "interop.delay"
+	InteropEnabledFlagName   = "interop.enabled"
+	InteropAutoRelayFlagName = "interop.autorelay"
+	InteropDelayFlagName     = "interop.delay"
 )
 
 var documentationLinks = []struct {
@@ -104,7 +104,7 @@ func ForkCLIFlags(envPrefix string) []cli.Flag {
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_ENABLED"),
 		},
 		&cli.BoolFlag{
-			Name:    InteropInclusionDelayFlagName,
+			Name:    InteropDelayFlagName,
 			Value:   false, // enabled by default
 			Usage:   "enable interop inclusion delay functionality",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_INCLUSION_DELAY"),
@@ -117,8 +117,8 @@ type ForkCLIConfig struct {
 	Network      string
 	Chains       []string
 
-	InteropEnabled        bool
-	InteropInclusionDelay uint64
+	InteropEnabled bool
+	InteropDelay   uint64
 }
 
 type CLIConfig struct {
@@ -127,8 +127,8 @@ type CLIConfig struct {
 	L1Port         uint64
 	L2StartingPort uint64
 
-	InteropAutoRelay      bool
-	InteropInclusionDelay uint64
+	InteropAutoRelay bool
+	InteropDelay     uint64
 
 	LogsDirectory string
 
@@ -142,8 +142,8 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 		L1Port:         ctx.Uint64(L1PortFlagName),
 		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
 
-		InteropAutoRelay:      ctx.Bool(InteropAutoRelayFlagName),
-		InteropInclusionDelay: ctx.Uint64(InteropInclusionDelayFlagName),
+		InteropAutoRelay: ctx.Bool(InteropAutoRelayFlagName),
+		InteropDelay:     ctx.Uint64(InteropDelayFlagName),
 
 		LogsDirectory: ctx.String(LogsDirectoryFlagName),
 	}
@@ -154,8 +154,8 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 			Network:      ctx.String(NetworkFlagName),
 			Chains:       ctx.StringSlice(ChainsFlagName),
 
-			InteropEnabled:        ctx.Bool(InteropEnabledFlagName),
-			InteropInclusionDelay: ctx.Uint64(InteropInclusionDelayFlagName),
+			InteropEnabled: ctx.Bool(InteropEnabledFlagName),
+			InteropDelay:   ctx.Uint64(InteropDelayFlagName),
 		}
 	}
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -28,7 +28,7 @@ const (
 
 	InteropEnabledFlagName        = "interop.enabled"
 	InteropAutoRelayFlagName      = "interop.autorelay"
-	InteropInclusionDelayFlagName = "interop.inclusiondelay"
+	InteropInclusionDelayFlagName = "interop.delay"
 )
 
 var documentationLinks = []struct {
@@ -118,7 +118,7 @@ type ForkCLIConfig struct {
 	Chains       []string
 
 	InteropEnabled        bool
-	InteropInclusionDelay bool
+	InteropInclusionDelay uint64
 }
 
 type CLIConfig struct {
@@ -128,7 +128,7 @@ type CLIConfig struct {
 	L2StartingPort uint64
 
 	InteropAutoRelay      bool
-	InteropInclusionDelay bool
+	InteropInclusionDelay uint64
 
 	LogsDirectory string
 
@@ -143,7 +143,7 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 		L2StartingPort: ctx.Uint64(L2StartingPortFlagName),
 
 		InteropAutoRelay:      ctx.Bool(InteropAutoRelayFlagName),
-		InteropInclusionDelay: ctx.Bool(InteropInclusionDelayFlagName),
+		InteropInclusionDelay: ctx.Uint64(InteropInclusionDelayFlagName),
 
 		LogsDirectory: ctx.String(LogsDirectoryFlagName),
 	}
@@ -155,7 +155,7 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 			Chains:       ctx.StringSlice(ChainsFlagName),
 
 			InteropEnabled:        ctx.Bool(InteropEnabledFlagName),
-			InteropInclusionDelay: ctx.Bool(InteropInclusionDelayFlagName),
+			InteropInclusionDelay: ctx.Uint64(InteropInclusionDelayFlagName),
 		}
 	}
 

--- a/docs/src/reference/supersim-fork.md
+++ b/docs/src/reference/supersim-fork.md
@@ -80,6 +80,9 @@ OPTIONS:
           --interop.autorelay                 (default: false)                   ($SUPERSIM_INTEROP_AUTORELAY)
                 Automatically relay messages sent to the L2ToL2CrossDomainMessenger using
                 account 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
+          
+          --interop.delay value               (default: 0)                       ($SUPERSIM_INTEROP_DELAY)
+                Delay before relaying messages sent to the L2ToL2CrossDomainMessenger
 
           --logs.directory value                                                 ($SUPERSIM_LOGS_DIRECTORY)
                 Directory to store logs

--- a/docs/src/reference/supersim.md
+++ b/docs/src/reference/supersim.md
@@ -82,6 +82,9 @@ GLOBAL OPTIONS:
           Automatically relay messages sent to the L2ToL2CrossDomainMessenger using
           account 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
 
+    --interop.delay value               (default: 0)                       ($SUPERSIM_INTEROP_DELAY)
+          Delay before relaying messages sent to the L2ToL2CrossDomainMessenger
+
     --l1.port value                     (default: 8545)                    ($SUPERSIM_L1_PORT)
           Listening port for the L1 instance. `0` binds to any available port
 

--- a/interop/indexer.go
+++ b/interop/indexer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -26,7 +25,6 @@ type L2ToL2MessageIndexer struct {
 	tasks        tasks.Group
 	tasksCtx     context.Context
 	tasksCancel  context.CancelFunc
-	interopDelay bool
 }
 
 func NewL2ToL2MessageIndexer(log log.Logger) *L2ToL2MessageIndexer {
@@ -131,10 +129,6 @@ func (i *L2ToL2MessageIndexer) processEventLog(ctx context.Context, backend ethe
 			return fmt.Errorf("failed to handle SentMessage event: %w", err)
 		}
 
-		if i.interopDelay {
-			time.Sleep(5 * time.Second)
-		}
-
 		i.logMessageEvent("SentMessage", entry, log)
 		i.eb.Publish(sentMessageFromSourceKey(entry.message.Source), entry)
 		i.eb.Publish(sentMessageToDestinationKey(entry.message.Destination), entry)
@@ -192,8 +186,4 @@ func getIdentifier(ctx context.Context, backend ethereum.ChainReader, chainID ui
 		Timestamp:   big.NewInt(int64(blockHeader.Time)),
 		ChainId:     big.NewInt(int64(chainID)),
 	}, nil
-}
-
-func (i *L2ToL2MessageIndexer) SetInteropDelay(delay bool) {
-	i.interopDelay = delay
 }

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -44,6 +44,9 @@ type OpSimulator struct {
 
 	l1Chain config.Chain
 
+	interopDelayEnabled bool
+	interopDelayTime    uint64
+
 	// Long running tasks
 	bgTasks       tasks.Group
 	bgTasksCtx    context.Context
@@ -60,7 +63,7 @@ type OpSimulator struct {
 }
 
 // OpSimulator wraps around the l2 chain. By embedding `Chain`, it also implements the same inteface
-func New(log log.Logger, closeApp context.CancelCauseFunc, port uint64, l1Chain, l2Chain config.Chain, peers map[uint64]config.Chain) *OpSimulator {
+func New(log log.Logger, closeApp context.CancelCauseFunc, port uint64, l1Chain, l2Chain config.Chain, peers map[uint64]config.Chain, interopDelayEnabled bool) *OpSimulator {
 	bgTasksCtx, bgTasksCancel := context.WithCancel(context.Background())
 
 	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, l2Chain.EthClient())
@@ -71,10 +74,12 @@ func New(log log.Logger, closeApp context.CancelCauseFunc, port uint64, l1Chain,
 	return &OpSimulator{
 		Chain: l2Chain,
 
-		log:          log.New("chain.id", l2Chain.Config().ChainID),
-		port:         port,
-		l1Chain:      l1Chain,
-		crossL2Inbox: crossL2Inbox,
+		log:                 log.New("chain.id", l2Chain.Config().ChainID),
+		port:                port,
+		l1Chain:             l1Chain,
+		crossL2Inbox:        crossL2Inbox,
+		interopDelayEnabled: interopDelayEnabled,
+		interopDelayTime:    5,
 
 		bgTasksCtx:    bgTasksCtx,
 		bgTasksCancel: bgTasksCancel,
@@ -410,6 +415,20 @@ func (opSim *OpSimulator) checkInteropInvariants(ctx context.Context, logs []typ
 			initiatingMsgPayloadHash := crypto.Keccak256Hash(interop.ExecutingMessagePayloadBytes(&initiatingMessageLogs[0]))
 			if common.BytesToHash(executingMessage.MsgHash[:]).Cmp(initiatingMsgPayloadHash) != 0 {
 				return fmt.Errorf("executing and initiating message fields are not equal")
+			}
+
+			if opSim.interopDelayEnabled {
+				// Add time check after getting the initiating message block header
+				executingBlockHeader, err := opSim.ethClient.HeaderByNumber(ctx, nil)
+				if err != nil {
+					return fmt.Errorf("failed to fetch executing block header: %w", err)
+				}
+
+				// Check if at least 5 seconds have passed
+				if executingBlockHeader.Time < identifierBlockHeader.Time+opSim.interopDelayTime {
+					return fmt.Errorf("not enough time has passed since initiating message (need 5s, got %ds)",
+						executingBlockHeader.Time-identifierBlockHeader.Time)
+				}
 			}
 		}
 	}

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -417,15 +417,15 @@ func (opSim *OpSimulator) checkInteropInvariants(ctx context.Context, logs []typ
 
 			if opSim.interopDelay != 0 {
 				// Add time check after getting the initiating message block header
-				executingBlockHeader, err := opSim.ethClient.HeaderByNumber(ctx, nil)
+				header, err := opSim.ethClient.HeaderByNumber(ctx, nil)
 				if err != nil {
 					return fmt.Errorf("failed to fetch executing block header: %w", err)
 				}
 
 				// Check if at least 5 seconds have passed
-				if executingBlockHeader.Time < identifierBlockHeader.Time+opSim.interopDelay {
+				if header.Time < identifierBlockHeader.Time+opSim.interopDelay {
 					return fmt.Errorf("not enough time has passed since initiating message (need 5s, got %ds)",
-						executingBlockHeader.Time-identifierBlockHeader.Time)
+						header.Time-identifierBlockHeader.Time)
 				}
 			}
 		}

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -49,7 +49,7 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 	// Sping up OpSim to fornt the L2 instances
 	for i := range networkConfig.L2Configs {
 		cfg := networkConfig.L2Configs[i]
-		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils)
+		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropInclusionDelay)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {
@@ -64,9 +64,6 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 		o.l2ToL2MsgIndexer = interop.NewL2ToL2MessageIndexer(log)
 		if networkConfig.InteropAutoRelay {
 			o.l2ToL2MsgRelayer = interop.NewL2ToL2MessageRelayer(log)
-		}
-		if networkConfig.InteropInclusionDelay {
-			o.l2ToL2MsgIndexer.SetInteropDelay(true)
 		}
 	}
 

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -49,7 +49,7 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 	// Sping up OpSim to fornt the L2 instances
 	for i := range networkConfig.L2Configs {
 		cfg := networkConfig.L2Configs[i]
-		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropInclusionDelay)
+		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropDelay)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -65,6 +65,9 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 		if networkConfig.InteropAutoRelay {
 			o.l2ToL2MsgRelayer = interop.NewL2ToL2MessageRelayer(log)
 		}
+		if networkConfig.InteropInclusionDelay {
+			o.l2ToL2MsgIndexer.SetInteropDelay(true)
+		}
 	}
 
 	return &o, nil

--- a/supersim.go
+++ b/supersim.go
@@ -59,7 +59,7 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 
 	// Forward interop config
 	networkConfig.InteropAutoRelay = cliConfig.InteropAutoRelay
-	networkConfig.InteropDelay = cliConfig.InteropInclusionDelay
+	networkConfig.InteropDelay = cliConfig.InteropDelay
 
 	o, err := orchestrator.NewOrchestrator(log, closeApp, &networkConfig)
 	if err != nil {

--- a/supersim.go
+++ b/supersim.go
@@ -59,7 +59,7 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 
 	// Forward interop config
 	networkConfig.InteropAutoRelay = cliConfig.InteropAutoRelay
-	networkConfig.InteropInclusionDelay = cliConfig.InteropInclusionDelay
+	networkConfig.InteropDelay = cliConfig.InteropInclusionDelay
 
 	o, err := orchestrator.NewOrchestrator(log, closeApp, &networkConfig)
 	if err != nil {

--- a/supersim.go
+++ b/supersim.go
@@ -59,6 +59,7 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 
 	// Forward interop config
 	networkConfig.InteropAutoRelay = cliConfig.InteropAutoRelay
+	networkConfig.InteropInclusionDelay = cliConfig.InteropInclusionDelay
 
 	o, err := orchestrator.NewOrchestrator(log, closeApp, &networkConfig)
 	if err != nil {

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -116,6 +116,7 @@ func createTestSuite(t *testing.T, cliConfig *config.CLIConfig) *TestSuite {
 
 type ForkInteropTestSuiteOptions struct {
 	interopAutoRelay bool
+	interopDelay     uint64
 }
 
 func createForkedInteropTestSuite(t *testing.T, testOptions ForkInteropTestSuiteOptions) *InteropTestSuite {
@@ -128,6 +129,7 @@ func createForkedInteropTestSuite(t *testing.T, testOptions ForkInteropTestSuite
 			InteropEnabled: true,
 		},
 		InteropAutoRelay: testOptions.interopAutoRelay,
+		InteropDelay:     testOptions.interopDelay,
 	}
 	superchain := registry.Superchains[cliConfig.ForkConfig.Network]
 	srcChainCfg := config.OPChainByName(superchain, srcChain)
@@ -904,4 +906,114 @@ func TestForkAutoRelaySuperchainWETHTransferSucceeds(t *testing.T) {
 		return diff.Cmp(valueToTransfer) == 0, nil
 	})
 	assert.NoError(t, waitErr)
+}
+
+func TestInteropInvariantFailsWhenDelayTimeNotPassed(t *testing.T) {
+	t.Parallel()
+
+	testSuite := createInteropTestSuite(t, config.CLIConfig{
+		InteropDelay: 5,
+	})
+	privateKey, err := testSuite.DevKeys.Secret(devkeys.UserKey(0))
+	require.NoError(t, err)
+	fromAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	l2ToL2CrossDomainMessenger, err := bindings.NewL2ToL2CrossDomainMessenger(predeploys.L2toL2CrossDomainMessengerAddr, testSuite.SourceEthClient)
+	require.NoError(t, err)
+
+	// Create initiating message using L2ToL2CrossDomainMessenger
+	origin := predeploys.L2toL2CrossDomainMessengerAddr
+	parsedSchemaRegistryAbi, _ := abi.JSON(strings.NewReader(opbindings.SchemaRegistryABI))
+	data, err := parsedSchemaRegistryAbi.Pack("register", "uint256 value", common.HexToAddress("0x0000000000000000000000000000000000000000"), false)
+	require.NoError(t, err)
+
+	sourceTransactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.SourceChainID)
+	require.NoError(t, err)
+	tx, err := l2ToL2CrossDomainMessenger.SendMessage(sourceTransactor, testSuite.DestChainID, predeploys.SchemaRegistryAddr, data)
+	require.NoError(t, err)
+
+	initiatingMessageTxReceipt, err := bind.WaitMined(context.Background(), testSuite.SourceEthClient, tx)
+	require.NoError(t, err)
+	require.True(t, initiatingMessageTxReceipt.Status == 1, "initiating message transaction failed")
+
+	// Try to execute immediately without waiting for delay time
+	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.DestEthClient)
+	require.NoError(t, err)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	require.NoError(t, err)
+	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
+	identifier := bindings.ICrossL2InboxIdentifier{
+		Origin:      origin,
+		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
+		LogIndex:    big.NewInt(0),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
+		ChainId:     testSuite.SourceChainID,
+	}
+	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
+	require.NoError(t, err)
+
+	// Should fail because the delay time hasn't passed
+	_, err = crossL2Inbox.ExecuteMessage(transactor, identifier, fromAddress, initiatingMessageLog.Data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "delay time not passed")
+}
+
+func TestInteropInvariantSucceedsWithDelay(t *testing.T) {
+	t.Parallel()
+
+	testSuite := createInteropTestSuite(t, config.CLIConfig{
+		InteropDelay: 2, // 2 second delay
+	})
+	privateKey, err := testSuite.DevKeys.Secret(devkeys.UserKey(0))
+	require.NoError(t, err)
+
+	l2ToL2CrossDomainMessenger, err := bindings.NewL2ToL2CrossDomainMessenger(predeploys.L2toL2CrossDomainMessengerAddr, testSuite.SourceEthClient)
+	require.NoError(t, err)
+
+	// Create initiating message using L2ToL2CrossDomainMessenger
+	origin := predeploys.L2toL2CrossDomainMessengerAddr
+	parsedSchemaRegistryAbi, _ := abi.JSON(strings.NewReader(opbindings.SchemaRegistryABI))
+	data, err := parsedSchemaRegistryAbi.Pack("register", "uint256 value", common.HexToAddress("0x0000000000000000000000000000000000000000"), false)
+	require.NoError(t, err)
+
+	sourceTransactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.SourceChainID)
+	require.NoError(t, err)
+	tx, err := l2ToL2CrossDomainMessenger.SendMessage(sourceTransactor, testSuite.DestChainID, predeploys.SchemaRegistryAddr, data)
+	require.NoError(t, err)
+
+	initiatingMessageTxReceipt, err := bind.WaitMined(context.Background(), testSuite.SourceEthClient, tx)
+	require.NoError(t, err)
+	require.True(t, initiatingMessageTxReceipt.Status == 1, "initiating message transaction failed")
+
+	// Wait for delay time to pass
+	time.Sleep(2 * time.Second)
+
+	// progress forward blocks to ensure timestamps are updated
+	err = testSuite.DestEthClient.Client().CallContext(context.Background(), nil, "anvil_mine", uint64(3), uint64(2))
+	require.NoError(t, err)
+	err = testSuite.SourceEthClient.Client().CallContext(context.Background(), nil, "anvil_mine", uint64(3), uint64(2))
+	require.NoError(t, err)
+
+	l2tol2CDM, err := bindings.NewL2ToL2CrossDomainMessengerTransactor(predeploys.L2toL2CrossDomainMessengerAddr, testSuite.DestEthClient)
+	require.NoError(t, err)
+	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	require.NoError(t, err)
+	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
+	identifier := bindings.ICrossL2InboxIdentifier{
+		Origin:      origin,
+		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
+		LogIndex:    big.NewInt(0),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
+		ChainId:     testSuite.SourceChainID,
+	}
+	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
+	require.NoError(t, err)
+
+	// Should succeed because delay time has passed
+	tx, err = l2tol2CDM.RelayMessage(transactor, identifier, interop.ExecutingMessagePayloadBytes(initiatingMessageLog))
+	require.NoError(t, err)
+
+	receipt, err := bind.WaitMined(context.Background(), testSuite.DestEthClient, tx)
+	require.NoError(t, err)
+	require.True(t, receipt.Status == 1, "executing message transaction failed")
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- by default the inclusiondelay is false 
- adds --interop.inclusiondelay flag in cli which delays sent messages by 5 seconds

Todo:

- [x] write tests 
- [x] update documentation

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
#133 
