### PR TITLE
Typo Update cross-chain-contract-via-l2cdm.md

### DIFF
--- a/docs/src/guides/interop/cross-chain-contract-via-l2cdm.md
+++ b/docs/src/guides/interop/cross-chain-contract-via-l2cdm.md
@@ -23,7 +23,7 @@ This guide walks through the `CrossChainPingPong.sol` contract, focusing on high
 ## High level overview
 
 `CrossChainPingPong.sol` implements a cross-chain ping-pong game using the L2ToL2CrossDomainMessenger.
- * Players hit a virtual ** *ball* ** back and forth between allowed L2 chains. The game starts with a serve
+ * Players hit a virtual **ball** back and forth between allowed L2 chains. The game starts with a serve
  * from a designated start chain, and each hit increases the rally count. The contract tracks the last hitter's address, chain ID, and the current rally count.
 
 ### Diagram


### PR DESCRIPTION
I found a typo in the documentation at `docs/src/guides/interop/cross-chain-contract-via-l2cdm.md`.

In the **High level overview** section, the sentence:

```markdown
Players hit a virtual ** *ball* ** back and forth between allowed L2 chains.
```

contains incorrect formatting for the word "**ball**". The extra spaces and asterisk should be removed to correct the formatting.

Correct version:

```markdown
Players hit a virtual **ball** back and forth between allowed L2 chains.
```

### Importance of the Fix:

This fix is important because it ensures the correct formatting for the word "ball" and improves the overall readability of the documentation. Proper formatting enhances clarity and helps avoid any confusion for readers.