### PR TITLE
feat(admin): getL1ToL2MessageByTxHash(l1DepositTxHash)

### DIFF
--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -23,7 +23,7 @@ func TestAdminServerBasicFunctionality(t *testing.T) {
 	testlog := testlog.Logger(t, log.LevelInfo)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adminServer := NewAdminServer(testlog, 0, &networkConfig, nil)
+	adminServer := NewAdminServer(testlog, 0, &networkConfig, nil, nil)
 	t.Cleanup(func() { cancel() })
 
 	require.NoError(t, adminServer.Start(ctx))
@@ -46,7 +46,7 @@ func TestGetL1AddressesRPC(t *testing.T) {
 	testlog := testlog.Logger(t, log.LevelInfo)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adminServer := NewAdminServer(testlog, 0, &networkConfig, nil)
+	adminServer := NewAdminServer(testlog, 0, &networkConfig, nil, nil)
 	t.Cleanup(func() { cancel() })
 
 	require.NoError(t, adminServer.Start(ctx))

--- a/opsimulator/deposits.go
+++ b/opsimulator/deposits.go
@@ -36,7 +36,7 @@ type LogSubscriber interface {
 }
 
 // transforms Deposit event logs into DepositTx
-func SubscribeDepositTx(ctx context.Context, logSub LogSubscriber, depositContractAddr common.Address, ch chan<- *types.DepositTx) (ethereum.Subscription, error) {
+func SubscribeDepositTx(ctx context.Context, logSub LogSubscriber, depositContractAddr common.Address, ch chan<- *types.DepositTx, chLog chan<- *types.Log) (ethereum.Subscription, error) {
 	logCh := make(chan types.Log)
 	filterQuery := ethereum.FilterQuery{Addresses: []common.Address{depositContractAddr}, Topics: [][]common.Hash{{derive.DepositEventABIHash}}}
 	logSubscription, err := logSub.SubscribeFilterLogs(ctx, filterQuery, logCh)
@@ -61,6 +61,7 @@ func SubscribeDepositTx(ctx context.Context, logSub LogSubscriber, depositContra
 					continue
 				}
 				ch <- dep
+				chLog <- &log
 			case err := <-logErrCh:
 				errCh <- fmt.Errorf("log subscription error: %w", err)
 			case <-ctx.Done():

--- a/opsimulator/deposits_test.go
+++ b/opsimulator/deposits_test.go
@@ -62,8 +62,9 @@ func TestSubscribeDepositTx(t *testing.T) {
 	ctx := context.Background()
 
 	depositTxCh := make(chan *types.DepositTx, len(mockDepositTxs))
+	depositLogCh := make(chan *types.Log, len(mockDepositTxs))
 
-	sub, err := SubscribeDepositTx(ctx, &chain, common.HexToAddress(""), depositTxCh)
+	sub, err := SubscribeDepositTx(ctx, &chain, common.HexToAddress(""), depositTxCh, depositLogCh)
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -63,7 +63,7 @@ type OpSimulator struct {
 }
 
 // OpSimulator wraps around the l2 chain. By embedding `Chain`, it also implements the same inteface
-func New(log log.Logger, closeApp context.CancelCauseFunc, port uint64, host string, l1Chain, l2Chain config.Chain, peers map[uint64]config.Chain, interopDelay uint64) *OpSimulator {
+func New(log log.Logger, closeApp context.CancelCauseFunc, port uint64, host string, l1Chain, l2Chain config.Chain, peers map[uint64]config.Chain, interopDelay uint64, depositStoreManager *L1DepositStoreManager) *OpSimulator {
 	bgTasksCtx, bgTasksCancel := context.WithCancel(context.Background())
 
 	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, l2Chain.EthClient())

--- a/opsimulator/store.go
+++ b/opsimulator/store.go
@@ -1,0 +1,63 @@
+package opsimulator
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type L1DepositStore struct {
+	entryByHash map[common.Hash]*types.DepositTx
+	mu          sync.RWMutex
+}
+
+type L1DepositStoreManager struct {
+	store *L1DepositStore
+}
+
+func NewL1DepositStore() *L1DepositStore {
+	return &L1DepositStore{
+		entryByHash: make(map[common.Hash]*types.DepositTx),
+	}
+}
+
+func NewL1DepositStoreManager() *L1DepositStoreManager {
+	return &L1DepositStoreManager{
+		store: NewL1DepositStore(),
+	}
+}
+
+func (s *L1DepositStore) Set(txnHash common.Hash, entry *types.DepositTx) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entryByHash[txnHash] = entry
+	return nil
+}
+
+func (s *L1DepositStore) Get(txnHash common.Hash) (*types.DepositTx, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, exists := s.entryByHash[txnHash]
+
+	if !exists {
+		return nil, fmt.Errorf("Deposit txn not found")
+	}
+
+	return entry, nil
+}
+
+func (s *L1DepositStoreManager) Get(txnHash common.Hash) (*types.DepositTx, error) {
+	return s.store.Get(txnHash)
+}
+
+func (s *L1DepositStoreManager) Set(txnHash common.Hash, entry *types.DepositTx) error {
+	if err := s.store.Set(txnHash, entry); err != nil {
+		return fmt.Errorf("failed to store message: %w", err)
+	}
+
+	return nil
+}

--- a/opsimulator/store_test.go
+++ b/opsimulator/store_test.go
@@ -1,0 +1,28 @@
+package opsimulator
+
+import (
+	"math/rand"
+	"testing"
+
+	optestutils "github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestL1DepositStore_SetAndGet(t *testing.T) {
+	sm := NewL1DepositStoreManager()
+
+	rng := rand.New(rand.NewSource(int64(0)))
+	sourceHash := common.Hash{}
+	depInput := optestutils.GenerateDeposit(sourceHash, rng)
+	depTx := types.NewTx(depInput)
+	txnHash := depTx.Hash()
+
+	err := sm.store.Set(txnHash, depInput)
+	assert.NoError(t, err, "expect no error while store deposit txn ref")
+
+	retrievedEntry, err := sm.store.Get(txnHash)
+	assert.NoError(t, err, "expected no error when getting entry from store")
+	assert.Equal(t, depInput, retrievedEntry, "expected retrieved entry to equal stored entry")
+}

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -55,7 +55,7 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 	for i := range networkConfig.L2Configs {
 		cfg := networkConfig.L2Configs[i]
 
-		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, cfg.Host, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropDelay)
+		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, cfg.Host, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropDelay, depositStoreMngr)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -49,10 +49,12 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 		l2Anvils[cfg.ChainID] = l2Anvil
 	}
 
+	depositStoreMngr := opsimulator.NewL1DepositStoreManager()
+
 	// Sping up OpSim to fornt the L2 instances
 	for i := range networkConfig.L2Configs {
 		cfg := networkConfig.L2Configs[i]
-		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropDelay)
+		l2OpSims[cfg.ChainID] = opsimulator.New(log, closeApp, nextL2Port, l1Anvil, l2Anvils[cfg.ChainID], l2Anvils, networkConfig.InteropDelay, depositStoreMngr)
 
 		// only increment expected port if it has been specified
 		if nextL2Port > 0 {
@@ -70,7 +72,7 @@ func NewOrchestrator(log log.Logger, closeApp context.CancelCauseFunc, networkCo
 		}
 	}
 
-	a := admin.NewAdminServer(log, adminPort, networkConfig, o.l2ToL2MsgIndexer)
+	a := admin.NewAdminServer(log, adminPort, networkConfig, o.l2ToL2MsgIndexer, depositStoreMngr)
 
 	o.AdminServer = a
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
added getL1ToL2MessageByTxHash(l1DepositTxHash), essentially letting devs fetch L1ToL2Message via depositTxnHash


**Metadata**

- adds extra functionality requested in #204 