### PR TITLE
Fix Grammar and Spelling Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Below, find a list of all kinds of interesting projects built with Supersim - If
 - [SuperchainERC20 Starter Kit](https://github.com/ethereum-optimism/superchainerc20-starter) - A toolkit to get started with superchainERC20 - an implementation of ERC-7802 designed to enable asset interoperability in the Superchain
 - [Hyperlane DevX Demo](https://github.com/ethereum-optimism/supersim/tree/main/integrations/hyperlane) - A demo for the developer experience  when using Hyperlane as a wrapper over OP's Native Interop
 - [Infinity Pets](https://github.com/karlfloersch/infinity-pets) - An example of horizontally scalable smart contract system and frontend application
-- [Interop Interactions and Interopable token](https://github.com/ismailmoazami/Supersim-interactions-and-OpInteropToken-contracts) - Script for  transfering tokens seamlessly between local OP chains and sample token contract that is SuperchainERC20 bridgable called OpInteropToken.
+- [Interop Interactions and Interopable token](https://github.com/ismailmoazami/Supersim-interactions-and-OpInteropToken-contracts) - Script for  transferring tokens seamlessly between local OP chains and sample token contract that is SuperchainERC20 bridgable called OpInteropToken.
 
 
 ## 🤝 Contributing

--- a/docs/src/guides/interop/cross-chain-contract-via-l2cdm.md
+++ b/docs/src/guides/interop/cross-chain-contract-via-l2cdm.md
@@ -108,7 +108,7 @@ While not explicitly mentioned in the code, this contract's design implicitly as
 
 3. **Initialization State Considerations**:
 
-   The starting chain id is apart of the initcode, meaning a deployment with a differing value would result in a different address via CREATE2. This is a nice feature as there's an implicit agreement on the starting chain from the address.
+   The starting chain id is a part of the initcode, meaning a deployment with a differing value would result in a different address via CREATE2. This is a nice feature as there's an implicit agreement on the starting chain from the address.
 
    Without CREATE2, you would need to:
     - Manually track contract addresses for each chain.
@@ -148,7 +148,7 @@ function receiveBall(PingPongBall memory _ball) onlyCrossDomainCallback() extern
 }
 ```
 - The handler simply stores reference to the received ball
-- The handler can only be invokable by the cross chain messenger
+- The handler can only be invoked by the cross chain messenger
 - Since the contract is self-referential, the cross chain sender must be the same contract address
 
 #### 3. Hit The Ball Cross Chain


### PR DESCRIPTION
1. README.md
Changed: 
 "transfering" → "transferring"
Reason: Corrected spelling of "transferring" which follows standard English spelling rules with double 'r'.
2. docs/src/guides/interop/cross-chain-contract-via-l2cdm.md
Changed:
 "apart" → "a part"
Reason: Separated "apart" into "a part" as it refers to being a component of something, not being separated.
 "invokable" → "invoked"
Reason: Changed to proper passive voice form of the verb "invoke" for better technical accuracy.
