### PR TITLE
Adds odyssey support

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -90,6 +90,10 @@ func (a *Anvil) Start(ctx context.Context) error {
 		"--max-persisted-states", "5",
 	}
 
+	if a.cfg.OdysseyEnabled {
+		args = append(args, "--odyssey")
+	}
+
 	if a.cfg.L2Config != nil {
 		args = append(args, "--optimism")
 	}

--- a/config/chain.go
+++ b/config/chain.go
@@ -63,6 +63,9 @@ type ChainConfig struct {
 
 	// Optional
 	LogsDirectory string
+
+	// Optional
+	OdysseyEnabled bool
 }
 
 type NetworkConfig struct {

--- a/config/cli.go
+++ b/config/cli.go
@@ -34,6 +34,8 @@ const (
 	InteropEnabledFlagName   = "interop.enabled"
 	InteropAutoRelayFlagName = "interop.autorelay"
 	InteropDelayFlagName     = "interop.delay"
+
+	OdysseyEnabledFlagName = "odyssey.enabled"
 )
 
 var documentationLinks = []struct {
@@ -95,6 +97,12 @@ func BaseCLIFlags(envPrefix string) []cli.Flag {
 			Usage:   "Delay before relaying messages sent to the L2ToL2CrossDomainMessenger",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "INTEROP_DELAY"),
 		},
+		&cli.BoolFlag{
+			Name:    OdysseyEnabledFlagName,
+			Value:   false, // disabled by default
+			Usage:   "Enable odyssey experimental features",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "ODYSSEY_ENABLED"),
+		},
 	}
 }
 
@@ -135,6 +143,7 @@ type ForkCLIConfig struct {
 	Chains       []string
 
 	InteropEnabled bool
+	OdysseyEnabled bool
 }
 
 type CLIConfig struct {
@@ -145,6 +154,8 @@ type CLIConfig struct {
 
 	InteropAutoRelay bool
 	InteropDelay     uint64
+
+	OdysseyEnabled bool
 
 	LogsDirectory string
 
@@ -166,6 +177,8 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 
 		LogsDirectory: ctx.String(LogsDirectoryFlagName),
 
+		OdysseyEnabled: ctx.Bool(OdysseyEnabledFlagName),
+
 		L1Host: ctx.String(L1HostFlagName),
 		L2Host: ctx.String(L2HostFlagName),
 	}
@@ -177,6 +190,7 @@ func ReadCLIConfig(ctx *cli.Context) (*CLIConfig, error) {
 			Chains:       ctx.StringSlice(ChainsFlagName),
 
 			InteropEnabled: ctx.Bool(InteropEnabledFlagName),
+			OdysseyEnabled: ctx.Bool(OdysseyEnabledFlagName),
 		}
 	}
 

--- a/docs/src/reference/supersim-fork.md
+++ b/docs/src/reference/supersim-fork.md
@@ -100,6 +100,9 @@ OPTIONS:
           --log.pid                           (default: false)                   ($SUPERSIM_LOG_PID)
                 Show pid in the log
 
+          --odyssey.enabled                   (default: false)                   ($SUPERSIM_ODYSSEY_ENABLED)
+                Enable odyssey experimental features
+
           --help, -h                          (default: false)
                 show help
 ```

--- a/docs/src/reference/supersim.md
+++ b/docs/src/reference/supersim.md
@@ -108,6 +108,9 @@ GLOBAL OPTIONS:
     --logs.directory value                                                 ($SUPERSIM_LOGS_DIRECTORY)
           Directory to store logs
 
+    --odyssey.enabled                   (default: false)                   ($SUPERSIM_ODYSSEY_ENABLED)
+          Enable odyssey experimental features
+
    MISC
 
 

--- a/orchestrator/fork.go
+++ b/orchestrator/fork.go
@@ -60,6 +60,7 @@ func NetworkConfigFromForkCLIConfig(log log.Logger, envPrefix string, cliConfig 
 			RPCUrl:      l1RpcUrl,
 			BlockNumber: l1Header.Number.Uint64(),
 		},
+		OdysseyEnabled: cliConfig.OdysseyEnabled,
 	}
 
 	// L2s
@@ -106,6 +107,7 @@ func NetworkConfigFromForkCLIConfig(log log.Logger, envPrefix string, cliConfig 
 				L1ChainID:   superchain.Config.L1.ChainID,
 				L1Addresses: registry.Addresses[chainCfg.ChainID],
 			},
+			OdysseyEnabled: cliConfig.OdysseyEnabled,
 		}
 
 		if forkConfig.InteropEnabled {

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -21,7 +21,7 @@ func createTestSuite(t *testing.T, networkConfig *config.NetworkConfig) *TestSui
 	testlog := testlog.Logger(t, log.LevelInfo)
 
 	ctx, closeApp := context.WithCancelCause(context.Background())
-	orchestrator, _ := NewOrchestrator(testlog, closeApp, networkConfig, 0)
+	orchestrator, _ := NewOrchestrator(testlog, closeApp, &config.CLIConfig{}, networkConfig, 0)
 
 	t.Cleanup(func() {
 		closeApp(nil)

--- a/supersim.go
+++ b/supersim.go
@@ -64,7 +64,7 @@ func NewSupersim(log log.Logger, envPrefix string, closeApp context.CancelCauseF
 	networkConfig.InteropAutoRelay = cliConfig.InteropAutoRelay
 	networkConfig.InteropDelay = cliConfig.InteropDelay
 
-	o, err := orchestrator.NewOrchestrator(log, closeApp, &networkConfig, cliConfig.AdminPort)
+	o, err := orchestrator.NewOrchestrator(log, closeApp, cliConfig, &networkConfig, cliConfig.AdminPort)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create orchestrator")
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR introduces a new cli flag `--odyssey.enabled`. It adds support to start both the L1 & L2 anvil instances with [odyssey features enabled](https://book.getfoundry.sh/reference/cli/anvil?highlight=odyssey#anvil) allowing developers to start testing out more experimental features multichain
