### PR TITLE
chore: Release flow migration to CircleCI [2/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
 
 orbs:
   go: circleci/go@2.2.3
+  utils: ethereum-optimism/circleci-utils@0.0.11
 
 commands:
   # By default, CircleCI does not checkout any submodules
@@ -49,6 +50,22 @@ commands:
       - run:
           name: Setup golangci-lint
           command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin << parameters.version >>
+
+  install-goreleaser:
+    parameters:
+      version:
+        type: string
+        default: "2.5.1"
+    steps:
+      - run:
+          name: Install GoReleaser
+          command: |
+            echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+            sudo apt -q update -y
+            sudo apt -q install -y --no-install-recommends goreleaser=<< parameters.version >>
+      - run:
+          name: Output GoReleaser version
+          command: goreleaser --version
 
   install-go-modules:
     steps:
@@ -106,6 +123,20 @@ jobs:
           name: Run tests
           command: just test-go
           no_output_timeout: 20m
+    
+  go-release:
+    executor: default
+    steps:
+      - checkout-with-submodules
+      - install-goreleaser
+      - install-go-modules
+      - utils/get-github-access-token:
+          # We match the name of the token environment variable with what GoReleaser expects in .goreleaser.yaml
+          output-token-name: TAP_REPO_GITHUB_TOKEN
+      - run:
+          name: Run GoReleaser
+          # FIXME Just for the time being we add the --snapshot flag
+          command: goreleaser release --snapshot --clean
 
 workflows:
   main:
@@ -116,3 +147,14 @@ workflows:
       - go-tests:
           context:
             - oplabs-rpc-urls
+  release:
+    jobs:
+      - go-release:
+          filters: 
+            tags:
+              only: 
+                - /^v.*/
+            # Without explicitly ignoring all branches, CircleCI will run the job on all branches
+            # even if no tags have been pushed
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,9 @@ jobs:
       - checkout-with-submodules
       - install-goreleaser
       - install-go-modules
-      - utils/get-github-access-token
+      - utils/get-github-access-token:
+          # GoReleaser expects a GITHUB_TOKEN environment variable to be set
+          output-token-name: GITHUB_TOKEN
       - run:
           name: Run GoReleaser
           # FIXME Just for the time being we add the --snapshot flag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,8 @@ workflows:
   release:
     jobs:
       - go-release:
+          context:
+            - circleci-repo-supersim
           filters: 
             tags:
               only: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,7 @@ jobs:
       - checkout-with-submodules
       - install-goreleaser
       - install-go-modules
-      - utils/get-github-access-token:
-          # We match the name of the token environment variable with what GoReleaser expects in .goreleaser.yaml
-          output-token-name: TAP_REPO_GITHUB_TOKEN
+      - utils/get-github-access-token
       - run:
           name: Run GoReleaser
           # FIXME Just for the time being we add the --snapshot flag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
 
 orbs:
   go: circleci/go@2.2.3
-  utils: ethereum-optimism/circleci-utils@0.0.11
+  utils: ethereum-optimism/circleci-utils@0.0.12
 
 commands:
   # By default, CircleCI does not checkout any submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.55.0
 
 orbs:
   go: circleci/go@2.2.3
@@ -24,23 +24,6 @@ commands:
           name: Initialize submodules
           command: git submodule update --init --recursive
   
-  install-foundry:
-    steps:
-      # Since CircleCI only sources the $BASH_ENV before each step, we isolate our $PATH modification to a separate step
-      - run:
-          name: Setup $PATH for foundry
-          command: echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Install Foundry
-          command: |
-            curl -L https://foundry.paradigm.xyz | bash
-            foundryup
-      - run:
-          name: Output foundry versions
-          command: |
-            anvil --version
-            forge --version
-  
   install-golangci-lint:
     parameters:
       version:
@@ -60,9 +43,9 @@ commands:
       - run:
           name: Install GoReleaser
           command: |
-            echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
-            sudo apt -q update -y
-            sudo apt -q install -y --no-install-recommends goreleaser=<< parameters.version >>
+            echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+            apt -q update -y
+            apt -q install -y --no-install-recommends goreleaser=<< parameters.version >>
       - run:
           name: Output GoReleaser version
           command: goreleaser --version
@@ -88,7 +71,6 @@ jobs:
       FOUNDRY_PROFILE: ci
     steps:
       - checkout-with-submodules
-      - install-foundry
       - run:
           name: Run Forge build
           command: just build-contracts
@@ -110,7 +92,6 @@ jobs:
     executor: default
     steps:
       - checkout-with-submodules
-      - install-foundry
       - install-go-modules
       - run:
           # We need to "rename" some of the variables coming from the CircleCI context
@@ -135,8 +116,7 @@ jobs:
           output-token-name: GITHUB_TOKEN
       - run:
           name: Run GoReleaser
-          # FIXME Just for the time being we add the --snapshot flag
-          command: goreleaser release --snapshot --clean
+          command: goreleaser release --clean
 
 workflows:
   main:
@@ -155,7 +135,7 @@ workflows:
           filters: 
             tags:
               only: 
-                - /^v.*/
+                - /^v?\d+\.\d+\.\d+.*?/
             # Without explicitly ignoring all branches, CircleCI will run the job on all branches
             # even if no tags have been pushed
             branches:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,4 +38,3 @@ brews:
     repository:
       owner: ethereum-optimism
       name: homebrew-tap
-      token: "{{ .Env.TAP_REPO_GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Continuing the migration from GHA to CircleCI, the release flow is next.

- Added the `release` workflow that runs on tag push
  - There is a small existing issue where a tag referring to a commit that's not on `main` will still trigger this pipeline. Will be addressed in a separate PR since it's not a regression
- Updated version of the base image since the python version in `v0.35.0` was causing issues with `utils/get-github-access-token` command (see [here](https://app.circleci.com/pipelines/github/ethereum-optimism/supersim/42/workflows/4c7b30d4-7223-44b4-91bb-883de9681881/jobs/160))
- Removed the `install-foundry` command since the new image contains a compatible `foundry` version already
- Removed the `TAP_REPO_GITHUB_TOKEN` environment variable from `.goreleaser.yaml`. The `GITHUB_TOKEN` produced from `utils/get-github-access-token` has write permissions to both `supersim` and `homebrew-tap` so we no longer need two tokens

**Once this change is merged, the github release workflow should be disabled to prevent race conditions and duplicate releases**. Once the change is stable the github workflow will be deleted.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

The workflow has been tested on a dummy playground repository, see [here](https://app.circleci.com/pipelines/github/ethereum-optimism/supersim/50/workflows/614c0210-b461-4382-bab6-288b0228d94a)