### PR TITLE
chore: Manage dependencies using mise [3/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 executors:
   default:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.55.0
+    machine:
+      image: ubuntu-2204:2024.08.1
 
 orbs:
   go: circleci/go@2.2.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,12 @@ commands:
   install-dependencies:
     steps:
       - run:
+          name: Install mise
+          command: curl https://mise.run | MISE_INSTALL_PATH=/home/circleci/bin/mise sh
+      - run:
+          name: Activate mise
+          command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
+      - run:
           name: Install mise dependencies
           command: mise install
 
@@ -65,7 +71,6 @@ jobs:
     steps:
       - checkout-with-submodules
       - install-dependencies
-      - install-golangci-lint
       - run:
           name: Run linter
           command: just lint-go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,21 +34,11 @@ commands:
           name: Setup golangci-lint
           command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin << parameters.version >>
 
-  install-goreleaser:
-    parameters:
-      version:
-        type: string
-        default: "2.5.1"
+  install-dependencies:
     steps:
       - run:
-          name: Install GoReleaser
-          command: |
-            echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-            apt -q update -y
-            apt -q install -y --no-install-recommends goreleaser=<< parameters.version >>
-      - run:
-          name: Output GoReleaser version
-          command: goreleaser --version
+          name: Install mise dependencies
+          command: mise install
 
   install-go-modules:
     steps:
@@ -61,6 +51,7 @@ jobs:
     executor: default
     steps:
       - checkout-with-submodules
+      - install-dependencies
       - run:
           name: Check versions
           command: just check-monorepo-versions
@@ -71,6 +62,7 @@ jobs:
       FOUNDRY_PROFILE: ci
     steps:
       - checkout-with-submodules
+      - install-dependencies
       - run:
           name: Run Forge build
           command: just build-contracts
@@ -82,7 +74,7 @@ jobs:
     executor: default
     steps:
       - checkout-with-submodules
-      - install-go-modules
+      - install-dependencies
       - install-golangci-lint
       - run:
           name: Run linter
@@ -92,6 +84,7 @@ jobs:
     executor: default
     steps:
       - checkout-with-submodules
+      - install-dependencies
       - install-go-modules
       - run:
           # We need to "rename" some of the variables coming from the CircleCI context
@@ -109,10 +102,12 @@ jobs:
     executor: default
     steps:
       - checkout-with-submodules
-      - install-goreleaser
+      - install-dependencies
       - install-go-modules
       - utils/get-github-access-token:
-          # GoReleaser expects a GITHUB_TOKEN environment variable to be set
+          # GoReleaser uses the GITHUB_TOKEN environment variable to authenticate with GitHub
+          # 
+          # It's important that the token has write permissions both to this repository and to the homebrew-tap repository
           output-token-name: GITHUB_TOKEN
       - run:
           name: Run GoReleaser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,16 +24,6 @@ commands:
           name: Initialize submodules
           command: git submodule update --init --recursive
   
-  install-golangci-lint:
-    parameters:
-      version:
-        type: string
-        default: v1.63.4
-    steps:
-      - run:
-          name: Setup golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin << parameters.version >>
-
   install-dependencies:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           # to match what supersim expects
           name: Setup environment variables
           command: |
+            echo "export SUPERSIM_RPC_URL_MAINNET=$RPC_URL_ETHEREUM_MAINNET" >> $BASH_ENV
             echo "export SUPERSIM_RPC_URL_OP=$RPC_URL_OP_MAINNET" >> $BASH_ENV
             echo "export SUPERSIM_RPC_URL_BASE=$RPC_URL_BASE_MAINNET" >> $BASH_ENV
       - run:

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,8 @@
 set positional-arguments
 
+build-book:
+    mdbook build ./docs
+
 build-contracts:
     forge --version
     forge build --sizes --root ./contracts

--- a/README.md
+++ b/README.md
@@ -203,6 +203,24 @@ L2s: Predeploy Contracts Spec ( https://specs.optimism.io/protocol/predeploys.ht
 
 ### Development
 
+#### Software dependencies
+
+We use [`mise`](https://mise.jdx.dev/) as a dependency manager for these tools.
+Once properly installed, `mise` will provide the correct versions for each tool. `mise` does not
+replace any other installations of these binaries and will only serve these binaries when you are
+working inside of the `optimism` directory.
+
+##### Install `mise`
+
+Install `mise` by following the instructions provided on the
+[Getting Started page](https://mise.jdx.dev/getting-started.html#_1-install-mise-cli).
+
+##### Install dependencies
+
+```sh
+mise install
+```
+
 #### Running locally
 
 ```sh

--- a/mise.book.toml
+++ b/mise.book.toml
@@ -1,0 +1,12 @@
+# These dependencies are only required if you want to build the book
+
+[tools]
+
+# Cargo dependencies
+"cargo:mdbook" = "0.4.43"
+"cargo:mdbook-mermaid" = "0.14.1"
+
+[env]
+# On CI, when using the ci-builder image, we need to set the toolchain explicitly
+# so that we avoid the "rustup could not choose a version of cargo to run, because one wasn't specified explicitly" error
+RUSTUP_TOOLCHAIN = "1.83.0"

--- a/mise.book.toml
+++ b/mise.book.toml
@@ -1,12 +1,13 @@
 # These dependencies are only required if you want to build the book
+# 
+# To install them, run mise with --env book (or set the MISE_ENV variable to "book"):
+# 
+# mise --env book install
+# 
+# MISE_ENV=book mise install
 
 [tools]
 
 # Cargo dependencies
 "cargo:mdbook" = "0.4.43"
 "cargo:mdbook-mermaid" = "0.14.1"
-
-[env]
-# On CI, when using the ci-builder image, we need to set the toolchain explicitly
-# so that we avoid the "rustup could not choose a version of cargo to run, because one wasn't specified explicitly" error
-RUSTUP_TOOLCHAIN = "1.83.0"

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ just = "1.37.0"
 
 # Go dependencies
 "ubi:goreleaser/goreleaser" = "2.5.1"
+"ubi:golangci/golangci-lint" = "v1.63.4"
 
 # Foundry
 "ubi:foundry-rs/foundry[exe=forge]" = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,18 @@
+[tools]
+
+# Core dependencies
+go = "1.22.3"
+rust = "1.83.0"
+just = "1.37.0"
+
+# Go dependencies
+"ubi:goreleaser/goreleaser" = "2.5.1"
+
+# Foundry
+"ubi:foundry-rs/foundry[exe=forge]" = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
+
+# Foundry provides multiple binaries so we alias them here
+[alias]
+forge = "ubi:foundry-rs/foundry[exe=forge]"
+cast = "ubi:foundry-rs/foundry[exe=cast]"
+anvil = "ubi:foundry-rs/foundry[exe=anvil]"

--- a/mise.toml
+++ b/mise.toml
@@ -9,8 +9,12 @@ just = "1.37.0"
 "ubi:goreleaser/goreleaser" = "2.5.1"
 "ubi:golangci/golangci-lint" = "v1.63.4"
 
-# Foundry
-"ubi:foundry-rs/foundry[exe=forge]" = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
+# Foundry dependencies
+# Foundry is a special case because it supplies multiple binaries at the same
+# GitHub release, so we need to use the aliasing trick to get mise to not error
+forge = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+cast = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+anvil = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
 
 # Foundry provides multiple binaries so we alias them here
 [alias]


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Before moving on to the GitHub Pages publishing workflow, I added `mise` as a dependency manager. `mise` is being used in the [`optimism` monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/mise.toml) and provides a great way of managing tooling required for development.

It is an add-on, it does not break or affect any existing development flows, just provides a convenient way of setting up your development environment (as well as the CI environment).

To further optimize the CI runs, dependencies that are only required for book/docs building have been pulled out into a separate `mise.book.toml` file. See [configuration environments documentation](https://mise.jdx.dev/configuration/environments.html) for more information.

`mise` then allows us to use the bare `ubuntu` runner which is about 1 minute faster to setup.

Fixes #292 