### PR TITLE
chore: Migrate Github Pages publishing to CircleCI [4/N]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,31 @@ jobs:
           name: Run GoReleaser
           command: goreleaser release --clean
 
+  book-build:
+    executor: default
+    environment:
+      MISE_ENV: book
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Build book
+          command: just build-book
+      - persist_to_workspace:
+          root: ./docs
+          paths:
+            - book
+
+  book-publish:
+    executor: default
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/docs
+      - utils/get-github-access-token
+      - utils/github-pages-deploy:
+          src-pages-dir: /tmp/docs/book
+
 workflows:
   main:
     jobs:
@@ -118,6 +143,23 @@ workflows:
       - go-tests:
           context:
             - oplabs-rpc-urls
+      
+      # To tighten the security, we split the workflow that publishes GitHub Pages
+      # into two jobs and only expose the security context to the job that does the publishing
+      # 
+      # The build job will run on every PR to avoid unpleasant surprises if the book build fails on main
+      - book-build
+      # The publish job will only run on the main branch
+      - book-publish:
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - book-build
+          context:
+            - circleci-repo-supersim
+
   release:
     jobs:
       - go-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
 
 orbs:
   go: circleci/go@2.2.3
-  utils: ethereum-optimism/circleci-utils@0.0.12
+  utils: ethereum-optimism/circleci-utils@0.0.13
 
 commands:
   # By default, CircleCI does not checkout any submodules


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

**This PR builds on top of #319 and can be reviewed once that one is merged.**

Migrates the `deploy-docs.yaml` github workflow to CircleCI. To tigthen the security, the workflow is split into two jobs:

- `book-build` does not have access to any credentials and is only responsible for building the github pages artifacts
- `book-publish` receives the build artifacts and pushes them to github pages

`ethereum-optimism/circleci-utils` orb version was bumped to `0.0.13` since `0.0.12` had a small issue with publishing github pages.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

No-op publish has been tested [here](https://app.circleci.com/pipelines/github/ethereum-optimism/supersim/114/workflows/e03578c5-10ab-4fdc-9004-49f9d2124524/jobs/486). Dummy change in a book has been tested [here](https://app.circleci.com/pipelines/github/ethereum-optimism/supersim/115/workflows/90d4c3b9-9e7f-4e37-947a-256886621d8d/jobs/492)