### PR TITLE
chore: Update CircleCI configuration and GitHub token handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
 
 orbs:
   go: circleci/go@2.2.3
-  utils: ethereum-optimism/circleci-utils@0.0.13
+  utils: ethereum-optimism/circleci-utils@1.0.8
 
 commands:
   # By default, CircleCI does not checkout any submodules
@@ -100,11 +100,13 @@ jobs:
       - checkout-with-submodules
       - install-dependencies
       - install-go-modules
-      - utils/get-github-access-token:
+      - run:
+          name: Get GitHub token
+          command: |
+            echo "export GITHUB_TOKEN=$GITHUB_TOKEN_GOVERNANCE" >> $BASH_ENV
           # GoReleaser uses the GITHUB_TOKEN environment variable to authenticate with GitHub
           # 
           # It's important that the token has write permissions both to this repository and to the homebrew-tap repository
-          output-token-name: GITHUB_TOKEN
       - run:
           name: Run GoReleaser
           command: goreleaser release --clean
@@ -130,7 +132,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/docs
-      - utils/get-github-access-token
       - utils/github-pages-deploy:
           src-pages-dir: /tmp/docs/book
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes several changes to the `.circleci/config.yml` file to update the CircleCI configuration. The most important changes involve updating the version of the `ethereum-optimism/circleci-utils` orb and modifying how the GitHub token is retrieved and used in the jobs.

Updates to CircleCI configuration:

* Updated the `ethereum-optimism/circleci-utils` orb version from `0.0.13` to `1.0.8` in the `executors` section.
* Replaced the `utils/get-github-access-token` command with a custom `run` command to set the `GITHUB_TOKEN` environment variable in the `jobs` section.
* Removed the `utils/get-github-access-token` command in another part of the `jobs` section, simplifying the configuration.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
