### PR TITLE
feat: update auto-relayer to handle dependent message hashes

### DIFF
--- a/config/chain.go
+++ b/config/chain.go
@@ -82,6 +82,20 @@ type NetworkConfig struct {
 	InteropDelay     uint64
 }
 
+type TraceCallResult struct {
+	Type    string            `json:"type"`
+	From    common.Address    `json:"from"`
+	To      common.Address    `json:"to"`
+	Value   *hexutil.Big      `json:"value"`
+	Gas     hexutil.Uint64    `json:"gas"`
+	GasUsed hexutil.Uint64    `json:"gasUsed"`
+	Input   hexutil.Bytes     `json:"input"`
+	Output  hexutil.Bytes     `json:"output"`
+	Error   string            `json:"error"`
+	Revert  string            `json:"revert"`
+	Calls   []TraceCallResult `json:"calls"`
+}
+
 type Chain interface {
 	// Properties
 	Endpoint() string
@@ -90,6 +104,7 @@ type Chain interface {
 	EthClient() *ethclient.Client
 
 	// Additional methods
+	DebugTraceCall(ctx context.Context, tx *types.Transaction) (*TraceCallResult, error)
 	SimulatedLogs(ctx context.Context, tx *types.Transaction) ([]types.Log, error)
 	SetCode(ctx context.Context, result interface{}, address common.Address, code string) error
 	SetStorageAt(ctx context.Context, result interface{}, address common.Address, storageSlot string, storageValue string) error

--- a/interop/relayer.go
+++ b/interop/relayer.go
@@ -4,14 +4,21 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/tasks"
 	"github.com/ethereum-optimism/supersim/bindings"
+	"github.com/ethereum-optimism/supersim/config"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -23,11 +30,24 @@ type L2ToL2MessageRelayer struct {
 	l2ToL2MessageIndexer *L2ToL2MessageIndexer
 
 	clients map[uint64]*ethclient.Client
+	chains  map[uint64]config.Chain
 
 	tasks       tasks.Group
 	tasksCtx    context.Context
 	tasksCancel context.CancelFunc
+
+	// the messages stored in this mapping are keyed by the msgHash of the message that they
+	// depend on being relayed before they can be relayed.
+	messageWaitingPool            map[common.Hash][]*L2ToL2MessageStoreEntry
+	messageWaitingPoolMutex       sync.RWMutex
+	checkForDependentMsgHashMutex sync.RWMutex
 }
+
+var (
+	ErrDependentMsgNotSuccessful = hexutil.Encode(
+		crypto.Keccak256([]byte("DependentMessageNotSuccessful(bytes32)"))[:4],
+	)
+)
 
 func NewL2ToL2MessageRelayer(logger log.Logger) *L2ToL2MessageRelayer {
 	tasksCtx, tasksCancel := context.WithCancel(context.Background())
@@ -39,16 +59,19 @@ func NewL2ToL2MessageRelayer(logger log.Logger) *L2ToL2MessageRelayer {
 				fmt.Printf("unhandled indexer error: %v\n", err)
 			},
 		},
-		tasksCtx:    tasksCtx,
-		tasksCancel: tasksCancel,
+		tasksCtx:                      tasksCtx,
+		tasksCancel:                   tasksCancel,
+		messageWaitingPool:            make(map[common.Hash][]*L2ToL2MessageStoreEntry),
+		messageWaitingPoolMutex:       sync.RWMutex{},
+		checkForDependentMsgHashMutex: sync.RWMutex{},
 	}
 
 }
 
-func (r *L2ToL2MessageRelayer) Start(indexer *L2ToL2MessageIndexer, clients map[uint64]*ethclient.Client) error {
+func (r *L2ToL2MessageRelayer) Start(indexer *L2ToL2MessageIndexer, clients map[uint64]*ethclient.Client, chains map[uint64]config.Chain) error {
 	r.l2ToL2MessageIndexer = indexer
 	r.clients = clients
-
+	r.chains = chains
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	if err != nil {
 		return fmt.Errorf("failed to create dev keys: %w", err)
@@ -64,6 +87,54 @@ func (r *L2ToL2MessageRelayer) Start(indexer *L2ToL2MessageIndexer, clients map[
 	}
 
 	for destinationChainID, client := range r.clients {
+		r.tasks.Go(func() error {
+			relayedMsgChan := make(chan *L2ToL2MessageStoreEntry)
+			unsubscribe, err := r.l2ToL2MessageIndexer.SubscribeRelayedMessageToDestination(destinationChainID, relayedMsgChan)
+			if err != nil {
+				r.logger.Debug("failed to subscribe to sent message events", "err", err)
+				return fmt.Errorf("failed to subscribe to sent message events: %w", err)
+			}
+
+			transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(destinationChainID)))
+			if err != nil {
+				r.logger.Debug("failed to create transactor", "err", err)
+				return fmt.Errorf("failed to create transactor: %w", err)
+			}
+
+			l2tol2CDM, err := bindings.NewL2ToL2CrossDomainMessengerTransactor(predeploys.L2toL2CrossDomainMessengerAddr, client)
+			if err != nil {
+				r.logger.Debug("failed to create transactor", "err", err)
+				return fmt.Errorf("failed to create	transactor: %w", err)
+			}
+
+			for {
+				select {
+				case relayedMsg := <-relayedMsgChan:
+					r.checkForDependentMsgHashMutex.RLock()
+					defer r.checkForDependentMsgHashMutex.RUnlock()
+					r.messageWaitingPoolMutex.Lock()
+					if waitingMsgs, exists := r.messageWaitingPool[relayedMsg.msgHash]; exists {
+						delete(r.messageWaitingPool, relayedMsg.msgHash)
+						r.messageWaitingPoolMutex.Unlock()
+
+						for _, waitingMsg := range waitingMsgs {
+							if err := r.relayMessageWithRetry(l2tol2CDM, transactor, waitingMsg, 1); err != nil {
+								r.logger.Error("failed to relay waiting message", "err", err)
+								return err
+							}
+						}
+					} else {
+						r.messageWaitingPoolMutex.Unlock()
+					}
+				case <-r.tasksCtx.Done():
+					unsubscribe()
+					close(relayedMsgChan)
+					return nil
+				}
+			}
+
+		})
+
 		r.tasks.Go(func() error {
 			sentMessageCh := make(chan *L2ToL2MessageStoreEntry)
 			unsubscribe, err := r.l2ToL2MessageIndexer.SubscribeSentMessageToDestination(destinationChainID, sentMessageCh)
@@ -92,9 +163,21 @@ func (r *L2ToL2MessageRelayer) Start(indexer *L2ToL2MessageIndexer, clients map[
 					close(sentMessageCh)
 					return nil
 				case sentMessage := <-sentMessageCh:
-					if err := r.relayMessageWithRetry(l2tol2CDM, transactor, sentMessage, 1); err != nil {
-						r.logger.Error("failed to relay message after retries", "err", err)
+					dependentMsgHash, err := r.fetchDependentMsgHash(transactor, sentMessage, destinationChainID)
+					if err != nil {
+						r.logger.Error("failed to relay message while checking for dependent message", "err", err)
 						return err
+					}
+					if dependentMsgHash == nil {
+						if err := r.relayMessageWithRetry(l2tol2CDM, transactor, sentMessage, 1); err != nil {
+							r.logger.Error("failed to relay message after retries", "err", err)
+							return err
+						}
+					}
+					if dependentMsgHash != nil {
+						r.messageWaitingPoolMutex.Lock()
+						r.messageWaitingPool[*dependentMsgHash] = append(r.messageWaitingPool[*dependentMsgHash], sentMessage)
+						r.messageWaitingPoolMutex.Unlock()
 					}
 				}
 			}
@@ -121,5 +204,75 @@ func (r *L2ToL2MessageRelayer) relayMessageWithRetry(l2tol2CDM *bindings.L2ToL2C
 		}
 		return nil
 	}
+	return nil
+}
+
+func (r *L2ToL2MessageRelayer) fetchDependentMsgHash(transactor *bind.TransactOpts, sentMessage *L2ToL2MessageStoreEntry, destinationChainID uint64) (*common.Hash, error) {
+	r.checkForDependentMsgHashMutex.Lock()
+	defer r.checkForDependentMsgHashMutex.Unlock()
+	l2tol2CDMABI, err := abi.JSON(strings.NewReader(bindings.L2ToL2CrossDomainMessengerMetaData.ABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read l2tol2CDM abi: %w", err)
+	}
+
+	input, err := l2tol2CDMABI.Pack(
+		"relayMessage",
+		*sentMessage.Identifier(),
+		sentMessage.MessagePayload(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack relayMessage transaction data: %w", err)
+	}
+
+	chain, ok := r.chains[destinationChainID]
+	if !ok {
+		return nil, fmt.Errorf("no client found for chain ID %d", destinationChainID)
+	}
+
+	gasPrice, err := chain.EthClient().SuggestGasPrice(r.tasksCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to suggest gas price: %w", err)
+	}
+	header, err := chain.EthClient().HeaderByNumber(r.tasksCtx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest block: %w", err)
+	}
+
+	tx := types.NewTransaction(
+		0,
+		predeploys.L2toL2CrossDomainMessengerAddr,
+		big.NewInt(0),
+		header.GasLimit,
+		gasPrice,
+		input,
+	)
+
+	signedTx, err := transactor.Signer(transactor.From, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign transaction: %w", err)
+	}
+
+	traceCallResult, err := chain.DebugTraceCall(r.tasksCtx, signedTx)
+	if err != nil {
+		return nil, fmt.Errorf("autorelaying failed while simulating transaction: %w", err)
+	}
+
+	msgHash := checkForDependentMsgNotSuccessfulRevert(*traceCallResult)
+	return msgHash, nil
+}
+
+func checkForDependentMsgNotSuccessfulRevert(trace config.TraceCallResult) *common.Hash {
+	if trace.From == predeploys.L2toL2CrossDomainMessengerAddr && trace.Output != nil && len(trace.Output) >= 4 && hexutil.Encode(trace.Output[:4]) == ErrDependentMsgNotSuccessful {
+		msgHash := common.BytesToHash(trace.Output[4:])
+		return &msgHash
+	}
+
+	// Check nested calls
+	for _, call := range trace.Calls {
+		if msgHash := checkForDependentMsgNotSuccessfulRevert(call); msgHash != nil {
+			return msgHash
+		}
+	}
+
 	return nil
 }

--- a/interop/store.go
+++ b/interop/store.go
@@ -59,6 +59,7 @@ type L2ToL2MessageStoreEntry struct {
 	identifier *bindings.Identifier
 	log        *types.Log
 	lifecycle  *L2ToL2MessageLifecycle
+	msgHash    common.Hash
 }
 
 func (e *L2ToL2MessageStoreEntry) Message() *L2ToL2Message {
@@ -126,6 +127,7 @@ func (s *L2ToL2MessageStore) UpdateLifecycle(msgHash common.Hash, updater Update
 	newEntry := &L2ToL2MessageStoreEntry{
 		message:   entry.message,
 		lifecycle: newLifecycle,
+		msgHash:   entry.msgHash,
 	}
 
 	s.entryByHash[msgHash] = newEntry
@@ -167,6 +169,7 @@ func (m *L2ToL2MessageStoreManager) HandleSentEvent(log *types.Log, identifier *
 		identifier: identifier,
 		lifecycle:  lifecycle,
 		log:        log,
+		msgHash:    msgHash,
 	}
 
 	if err := m.store.Set(msgHash, entry); err != nil {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -146,7 +146,7 @@ func (o *Orchestrator) Start(ctx context.Context) error {
 
 		if o.l2ToL2MsgRelayer != nil {
 			o.log.Info("starting L2ToL2CrossDomainMessenger autorelayer") // `info` since it's explictily enabled
-			if err := o.l2ToL2MsgRelayer.Start(o.l2ToL2MsgIndexer, l2OpSimClientByChainId); err != nil {
+			if err := o.l2ToL2MsgRelayer.Start(o.l2ToL2MsgIndexer, l2OpSimClientByChainId, o.l2Chains); err != nil {
 				return fmt.Errorf("l2 to l2 message relayer failed to start: %w", err)
 			}
 		}

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -59,6 +59,10 @@ func (c *MockChain) EthClient() *ethclient.Client {
 	return nil
 }
 
+func (c *MockChain) DebugTraceCall(ctx context.Context, tx *types.Transaction) (*config.TraceCallResult, error) {
+	return nil, nil
+}
+
 func (c *MockChain) SimulatedLogs(ctx context.Context, tx *types.Transaction) ([]types.Log, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Updates the auto-relayer to handle messages that are dependent on one another. This is done by looking for messages that when relayed would revert with the `DependentMessageNotSuccessful(bytes32 msgHash)` error signature. If this revert is encountered, then the relayer will wait to relay this message until the msgHash that it depends on is successfully relayed.