### PR TITLE
fix: revert minimum anvil version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ var (
 )
 
 const (
-	minAnvilTimestamp = "2025-02-14T00:20:02.123144000Z"
+	minAnvilTimestamp = "2025-02-10T09:00:00.000000000Z"
 )
 
 func main() {


### PR DESCRIPTION
will update on next stable release. Otherwise we're forcing people to use nightly builds