### PR TITLE
fix: bump required anvil version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ var (
 )
 
 const (
-	minAnvilTimestamp = "2025-02-10T09:00:00.000000000Z"
+	minAnvilTimestamp = "2025-02-17T00:00:00.000000000Z"
 )
 
 func main() {


### PR DESCRIPTION
There is a bug in older versions of anvil that causes supersim to break so bumping to the min version of anvil that contains the fix: https://github.com/foundry-rs/foundry/releases/tag/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e

This bug is present when running > 2 l2 chains and causes `eth_call`'s to fail with:
```
error code -32003: Insufficient funds for gas * price + value
```

When looking into this it seems like this happens due to the way older versions of anvil handle deposit txs. 