### PR TITLE
feat: vary block time for chain

### DIFF
--- a/config/chain.go
+++ b/config/chain.go
@@ -19,6 +19,11 @@ import (
 	"github.com/ethereum/go-ethereum/superchain"
 )
 
+const (
+	DefaultL1BlockTime = 12
+	DefaultL2BlockTime = 2
+)
+
 var (
 	DefaultSecretsConfig = SecretsConfig{
 		Accounts:       10,
@@ -49,6 +54,8 @@ type ChainConfig struct {
 	Host    string
 	Port    uint64
 	ChainID uint64
+
+	BlockTime uint64
 
 	GenesisJSON   []byte
 	SecretsConfig SecretsConfig
@@ -130,6 +137,7 @@ func GetNetworkConfig(cliConfig *CLIConfig) NetworkConfig {
 		L1Config: ChainConfig{
 			Name:              "Local",
 			ChainID:           genesis.GeneratedGenesisDeployment.L1.ChainID,
+			BlockTime:         DefaultL1BlockTime,
 			SecretsConfig:     DefaultSecretsConfig,
 			GenesisJSON:       genesis.GeneratedGenesisDeployment.L1.GenesisJSON,
 			StartingTimestamp: startingTimestamp,
@@ -145,6 +153,7 @@ func GetNetworkConfig(cliConfig *CLIConfig) NetworkConfig {
 			GenesisJSON:       genesis.GeneratedGenesisDeployment.L2s[i].GenesisJSON,
 			StartingTimestamp: startingTimestamp,
 			LogsDirectory:     cliConfig.LogsDirectory,
+			BlockTime:         DefaultL2BlockTime,
 			L2Config: &L2Config{
 				L1ChainID:     genesis.GeneratedGenesisDeployment.L1.ChainID,
 				L1Addresses:   genesis.GeneratedGenesisDeployment.L2s[i].RegistryAddressList(),

--- a/orchestrator/fork.go
+++ b/orchestrator/fork.go
@@ -16,8 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/superchain"
 )
 
-const blockTime = 2
-
 func NetworkConfigFromForkCLIConfig(log log.Logger, envPrefix string, cliConfig *config.CLIConfig) (config.NetworkConfig, error) {
 	forkConfig := cliConfig.ForkConfig
 	superchain := registry.SuperchainsByIdentifier[forkConfig.Network]
@@ -54,6 +52,7 @@ func NetworkConfigFromForkCLIConfig(log log.Logger, envPrefix string, cliConfig 
 
 	networkConfig.L1Config = config.ChainConfig{
 		Name:          forkConfig.Network,
+		BlockTime:     config.DefaultL1BlockTime,
 		ChainID:       superchain.Config.L1.ChainID,
 		SecretsConfig: config.DefaultSecretsConfig,
 		LogsDirectory: cliConfig.LogsDirectory,
@@ -98,6 +97,7 @@ func NetworkConfigFromForkCLIConfig(log log.Logger, envPrefix string, cliConfig 
 		l2ChainConfig := config.ChainConfig{
 			Name:          chainCfg.Name,
 			ChainID:       chainCfg.ChainID,
+			BlockTime:     config.DefaultL1BlockTime,
 			SecretsConfig: config.DefaultSecretsConfig,
 			LogsDirectory: cliConfig.LogsDirectory,
 			ForkConfig: &config.ForkConfig{
@@ -143,8 +143,8 @@ func latestL2HeightFromL1Header(l2Cfg *superchain.ChainConfig, l2Client *ethclie
 	blockNum := latestHeader.Number.Uint64()
 	if latestHeader.Time > l1Header.Time {
 		timeDiff := latestHeader.Time - l1Header.Time
-		blocksToWalkBack := timeDiff / blockTime
-		if timeDiff%2 != 0 {
+		blocksToWalkBack := timeDiff / l2Cfg.BlockTime
+		if timeDiff%l2Cfg.BlockTime != 0 {
 			blocksToWalkBack++
 		}
 		blockNum = blockNum - blocksToWalkBack

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -201,7 +201,7 @@ func (o *Orchestrator) Stop(ctx context.Context) error {
 }
 
 func (o *Orchestrator) kickOffMining(ctx context.Context) error {
-	if err := o.l1Chain.SetIntervalMining(ctx, nil, 2); err != nil {
+	if err := o.l1Chain.SetIntervalMining(ctx, nil, int64(o.config.L1Config.BlockTime)); err != nil {
 		return errors.New("failed to start interval mining on l1")
 	}
 
@@ -211,7 +211,7 @@ func (o *Orchestrator) kickOffMining(ctx context.Context) error {
 	errs := make([]error, len(o.l2Chains))
 	for i, chain := range o.L2Chains() {
 		go func(i int) {
-			if err := chain.SetIntervalMining(ctx, nil, 2); err != nil {
+			if err := chain.SetIntervalMining(ctx, nil, int64(chain.Config().BlockTime)); err != nil {
 				errs[i] = fmt.Errorf("failed to start interval mining for chain %s", chain.Config().Name)
 			}
 

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -42,8 +42,9 @@ func (c *MockChain) String() string {
 
 func (c *MockChain) Config() *config.ChainConfig {
 	return &config.ChainConfig{
-		Name:    "mockchain",
-		ChainID: 1,
+		Name:      "mockchain",
+		ChainID:   1,
+		BlockTime: 2,
 	}
 }
 


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/supersim/issues/305

### context
- previously both L1 and L2 chains had a hardcoded block time of 2s
- fork mode also assumed this to calculate l2 block height based on the l1 block height

### changes
- default block time for L1 is 12s
- default block time for L2s is 2s
- when forking, it reads block time from the superchain registry (ie. unichain should be 1s) for both 1. inferring l2 block height from l1, 2. the mining speed on the forked chain
