### PR TITLE
fix: remove redundant cat

### DIFF
--- a/scripts/vendor-superchain-registry.sh
+++ b/scripts/vendor-superchain-registry.sh
@@ -16,7 +16,7 @@ check_prerequisites() {
         exit 1
     fi
 
-    COMMIT_HASH=$(cat "$COMMIT_FILE" | tr -d '[:space:]')
+    COMMIT_HASH=$(tr -d '[:space:]' < "$COMMIT_FILE")
     if [ -z "$COMMIT_HASH" ]; then
         echo "Error: $COMMIT_FILE is empty" >&2
         exit 1


### PR DESCRIPTION
**Description**

I noticed that `cat` was unnecessarily used to read the commit file. Replaced it with a more efficient approach using input redirection. The behavior remains the same, but it's cleaner now.