### PR TITLE
Enable websocket support on l2 chains - propagating ws connection to anvil approach

### DIFF
--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -290,6 +290,10 @@ func (a *Anvil) EthClient() *ethclient.Client {
 	return a.ethClient
 }
 
+func (a *Anvil) RpcClient() *rpc.Client {
+	return a.rpcClient
+}
+
 func (a *Anvil) SetCode(ctx context.Context, result interface{}, address common.Address, code string) error {
 	return a.rpcClient.CallContext(ctx, result, "anvil_setCode", address.Hex(), code)
 }

--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -290,10 +290,6 @@ func (a *Anvil) EthClient() *ethclient.Client {
 	return a.ethClient
 }
 
-func (a *Anvil) RpcClient() *rpc.Client {
-	return a.rpcClient
-}
-
 func (a *Anvil) SetCode(ctx context.Context, result interface{}, address common.Address, code string) error {
 	return a.rpcClient.CallContext(ctx, result, "anvil_setCode", address.Hex(), code)
 }

--- a/anvil/anvil.go
+++ b/anvil/anvil.go
@@ -234,7 +234,7 @@ func (a *Anvil) Start(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	rpcClient, err := rpc.Dial(a.wsEndpoint())
+	rpcClient, err := rpc.Dial(a.WSEndpoint())
 	if err != nil {
 		return fmt.Errorf("failed to create RPC client: %w", err)
 	}
@@ -266,7 +266,7 @@ func (a *Anvil) Endpoint() string {
 	return fmt.Sprintf("http://%s:%d", a.cfg.Host, a.cfg.Port)
 }
 
-func (a *Anvil) wsEndpoint() string {
+func (a *Anvil) WSEndpoint() string {
 	return fmt.Sprintf("ws://%s:%d", a.cfg.Host, a.cfg.Port)
 }
 

--- a/config/chain.go
+++ b/config/chain.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/superchain"
 )
 
@@ -111,7 +110,6 @@ type Chain interface {
 	LogPath() string
 	Config() *ChainConfig
 	EthClient() *ethclient.Client
-	RpcClient() *rpc.Client
 
 	// Additional methods
 	DebugTraceCall(ctx context.Context, tx *types.Transaction) (*TraceCallResult, error)

--- a/config/chain.go
+++ b/config/chain.go
@@ -106,6 +106,7 @@ type TraceCallResult struct {
 type Chain interface {
 	// Properties
 	Endpoint() string
+	WSEndpoint() string
 	LogPath() string
 	Config() *ChainConfig
 	EthClient() *ethclient.Client

--- a/config/chain.go
+++ b/config/chain.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/superchain"
 )
 
@@ -110,6 +111,7 @@ type Chain interface {
 	LogPath() string
 	Config() *ChainConfig
 	EthClient() *ethclient.Client
+	RpcClient() *rpc.Client
 
 	// Additional methods
 	DebugTraceCall(ctx context.Context, tx *types.Transaction) (*TraceCallResult, error)

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -567,7 +567,7 @@ func (opSim *OpSimulator) handleWebSocket(w http.ResponseWriter, r *http.Request
 
 		response, err := opSim.processWSRequest(message, conn)
 		if err != nil {
-			opSim.log.Error("Failed to process RPC request", "error", err)
+			opSim.log.Error("Failed to process WS RPC request", "error", err)
 			continue
 		}
 

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -62,8 +62,7 @@ type OpSimulator struct {
 	stopped atomic.Bool
 
 	// WebSocket configuration
-	upgrader websocket.Upgrader
-
+	upgrader      websocket.Upgrader
 	subscriptions map[string]*websocket.Conn
 	subsMutex     sync.Mutex
 	clientConnMu  sync.Mutex

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -66,7 +66,7 @@ type OpSimulator struct {
 
 	subscriptions map[string]*websocket.Conn
 	subsMutex     sync.Mutex
-	clientConnMu  sync.Mutex // Add mutex to protect client connection writes
+	clientConnMu  sync.Mutex
 }
 
 type WSResponse struct {

--- a/opsimulator/opsimulator.go
+++ b/opsimulator/opsimulator.go
@@ -616,7 +616,6 @@ func (opSim *OpSimulator) processWSRequest(ctx context.Context, clientRequestMes
 				continue
 			}
 
-			// Send the subscribe request
 			msgBytes, err := json.Marshal(msg)
 			if err != nil {
 				batchRes[i] = msg.errorResponse(err)
@@ -643,7 +642,6 @@ func (opSim *OpSimulator) processWSRequest(ctx context.Context, clientRequestMes
 				continue
 			}
 
-			// Store the connection
 			opSim.subsMutex.Lock()
 			if opSim.subscriptions == nil {
 				opSim.subscriptions = make(map[string]*websocket.Conn)
@@ -685,7 +683,6 @@ func (opSim *OpSimulator) processWSRequest(ctx context.Context, clientRequestMes
 			continue
 		}
 
-		// Handle unsubscribe request
 		if msg.Method == "eth_unsubscribe" {
 			var params []string
 			if err := json.Unmarshal(msg.Params, &params); err != nil {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -241,6 +241,13 @@ func (o *Orchestrator) Endpoint(chainId uint64) string {
 	return o.l2OpSims[chainId].Endpoint()
 }
 
+func (o *Orchestrator) WSEndpoint(chainId uint64) string {
+	if o.l1Chain.Config().ChainID == chainId {
+		return o.l1Chain.WSEndpoint()
+	}
+	return o.l2OpSims[chainId].WSEndpoint()
+}
+
 func (o *Orchestrator) ConfigAsString() string {
 	var b strings.Builder
 	l1Cfg := o.l1Chain.Config()

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -2,6 +2,7 @@ package supersim
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strings"
 	"sync"
@@ -33,6 +34,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
 )
 
 const (
@@ -223,6 +225,36 @@ func TestStartup(t *testing.T) {
 
 	// test that l1 anvil can be queried
 	l1Client, err := rpc.Dial(testSuite.Supersim.Orchestrator.L1Chain().Endpoint())
+	require.NoError(t, err)
+
+	var chainId gethmath.HexOrDecimal64
+	require.NoError(t, l1Client.CallContext(context.Background(), &chainId, "eth_chainId"))
+	require.Equal(t, testSuite.Supersim.Orchestrator.L1Chain().Config().ChainID, uint64(chainId))
+
+	l1Client.Close()
+}
+
+func TestWsStartup(t *testing.T) {
+	t.Parallel()
+	testSuite := createTestSuite(t)
+
+	l2Chains := testSuite.Supersim.Orchestrator.L2Chains()
+	require.True(t, len(l2Chains) > 0)
+
+	// test that all chains can be queried
+	for _, chain := range l2Chains {
+		l2Client, err := rpc.DialWebsocket(context.Background(), chain.WSEndpoint(), "")
+		require.NoError(t, err)
+
+		var chainId gethmath.HexOrDecimal64
+		require.NoError(t, l2Client.CallContext(context.Background(), &chainId, "eth_chainId"))
+		require.Equal(t, chain.Config().ChainID, uint64(chainId))
+
+		l2Client.Close()
+	}
+
+	// test that l1 anvil can be queried
+	l1Client, err := rpc.DialWebsocket(context.Background(), testSuite.Supersim.Orchestrator.L1Chain().WSEndpoint(), "")
 	require.NoError(t, err)
 
 	var chainId gethmath.HexOrDecimal64
@@ -429,6 +461,27 @@ func TestBatchJsonRpcRequests(t *testing.T) {
 	}
 }
 
+func TestBatchJsonRpcRequestsWs(t *testing.T) {
+	t.Parallel()
+	testSuite := createTestSuite(t)
+
+	for _, chain := range testSuite.Supersim.Orchestrator.L2Chains() {
+		client, err := ethclient.Dial(testSuite.Supersim.Orchestrator.WSEndpoint(chain.Config().ChainID))
+		require.NoError(t, err)
+		defer client.Close()
+
+		elems := []rpc.BatchElem{{Method: "eth_chainId", Result: new(hexutil.Uint64)}, {Method: "eth_blockNumber", Result: new(hexutil.Uint64)}}
+		require.NoError(t, client.Client().BatchCall(elems))
+
+		require.Nil(t, elems[0].Error)
+		require.Nil(t, elems[1].Error)
+
+		require.NotZero(t, uint64(*(elems[0].Result).(*hexutil.Uint64)))
+		// TODO: fix later, this occasionally fails when we set anvil on block-time 2
+		// require.NotZero(t, uint64(*(elems[1].Result).(*hexutil.Uint64)))
+	}
+}
+
 func TestBatchJsonRpcRequestErrorHandling(t *testing.T) {
 	t.Parallel()
 	testSuite := createInteropTestSuite(t)
@@ -549,6 +602,70 @@ func TestInteropInvariantCheckSucceeds(t *testing.T) {
 	require.True(t, receipt.Status == 1, "initiating message transaction failed")
 }
 
+func TestInteropInvariantCheckSucceedsWs(t *testing.T) {
+	t.Parallel()
+	testSuite := createInteropTestSuite(t)
+
+	sourceClient, err := ethclient.Dial(testSuite.Supersim.Orchestrator.WSEndpoint(testSuite.Supersim.NetworkConfig.L2Configs[0].ChainID))
+	require.NoError(t, err)
+	defer sourceClient.Close()
+
+	destClient, err := ethclient.Dial(testSuite.Supersim.Orchestrator.WSEndpoint(testSuite.Supersim.NetworkConfig.L2Configs[1].ChainID))
+	require.NoError(t, err)
+	defer destClient.Close()
+
+	privateKey, err := testSuite.DevKeys.Secret(devkeys.UserKey(0))
+	require.NoError(t, err)
+
+	l2ToL2CrossDomainMessenger, err := bindings.NewL2ToL2CrossDomainMessenger(predeploys.L2toL2CrossDomainMessengerAddr, sourceClient)
+	require.NoError(t, err)
+
+	// Create initiating message using L2ToL2CrossDomainMessenger
+	origin := predeploys.L2toL2CrossDomainMessengerAddr
+	parsedSchemaRegistryAbi, _ := abi.JSON(strings.NewReader(opbindings.SchemaRegistryABI))
+	data, err := parsedSchemaRegistryAbi.Pack("register", "uint256 value", common.HexToAddress("0x0000000000000000000000000000000000000000"), false)
+	require.NoError(t, err)
+
+	sourceTransactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.SourceChainID)
+	require.NoError(t, err)
+	tx, err := l2ToL2CrossDomainMessenger.SendMessage(sourceTransactor, testSuite.DestChainID, predeploys.SchemaRegistryAddr, data)
+	require.NoError(t, err)
+
+	initiatingMessageTxReceipt, err := bind.WaitMined(context.Background(), sourceClient, tx)
+	require.NoError(t, err)
+	require.True(t, initiatingMessageTxReceipt.Status == 1, "initiating message transaction failed")
+
+	// progress forward one block before sending tx
+	err = testSuite.DestEthClient.Client().CallContext(context.Background(), nil, "anvil_mine", uint64(3), uint64(2))
+	require.NoError(t, err)
+	err = sourceClient.Client().CallContext(context.Background(), nil, "anvil_mine", uint64(3), uint64(2))
+	require.NoError(t, err)
+
+	l2tol2CDM, err := bindings.NewL2ToL2CrossDomainMessengerTransactor(predeploys.L2toL2CrossDomainMessengerAddr, destClient)
+	require.NoError(t, err)
+	initiatingMessageBlockHeader, err := sourceClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	require.NoError(t, err)
+	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
+	identifier := bindings.Identifier{
+		Origin:      origin,
+		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
+		LogIndex:    big.NewInt(0),
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
+		ChainId:     testSuite.SourceChainID,
+	}
+	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
+	require.NoError(t, err)
+	transactor.AccessList = interop.MessageAccessList(&identifier, interop.ExecutingMessagePayloadBytes(initiatingMessageLog))
+
+	// Should succeed
+	tx, err = l2tol2CDM.RelayMessage(transactor, identifier, interop.ExecutingMessagePayloadBytes(initiatingMessageLog))
+	require.NoError(t, err)
+
+	receipt, err := bind.WaitMined(context.Background(), testSuite.DestEthClient, tx)
+	require.NoError(t, err)
+	require.True(t, receipt.Status == 1, "initiating message transaction failed")
+}
+
 func TestInteropInvariantCheckFailsBadLogIndex(t *testing.T) {
 	t.Parallel()
 	testSuite := createInteropTestSuite(t)
@@ -583,6 +700,68 @@ func TestInteropInvariantCheckFailsBadLogIndex(t *testing.T) {
 	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.DestEthClient)
 	require.NoError(t, err)
 	initiatingMessageBlockHeader, err := testSuite.SourceEthClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
+	require.NoError(t, err)
+
+	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
+	identifier := bindings.Identifier{
+		Origin:      origin,
+		BlockNumber: initiatingMessageTxReceipt.BlockNumber,
+		LogIndex:    big.NewInt(5), // Wrong index
+		Timestamp:   new(big.Int).SetUint64(initiatingMessageBlockHeader.Time),
+		ChainId:     testSuite.SourceChainID,
+	}
+	transactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.DestChainID)
+	require.NoError(t, err)
+
+	transactor.AccessList = interop.MessageAccessList(&identifier, interop.ExecutingMessagePayloadBytes(initiatingMessageLog))
+
+	// Should fail because the log index is incorrect
+	_, err = crossL2Inbox.ValidateMessage(transactor, identifier, crypto.Keccak256Hash(interop.ExecutingMessagePayloadBytes(initiatingMessageLog)))
+	require.Error(t, err)
+}
+
+func TestInteropInvariantCheckFailsBadLogIndexWs(t *testing.T) {
+	t.Parallel()
+	testSuite := createInteropTestSuite(t)
+
+	sourceClient, err := ethclient.Dial(testSuite.Supersim.Orchestrator.WSEndpoint(testSuite.Supersim.NetworkConfig.L2Configs[0].ChainID))
+	require.NoError(t, err)
+	defer sourceClient.Close()
+
+	destClient, err := ethclient.Dial(testSuite.Supersim.Orchestrator.WSEndpoint(testSuite.Supersim.NetworkConfig.L2Configs[1].ChainID))
+	require.NoError(t, err)
+	defer destClient.Close()
+
+	privateKey, err := testSuite.DevKeys.Secret(devkeys.UserKey(0))
+	require.NoError(t, err)
+
+	l2ToL2CrossDomainMessenger, err := bindings.NewL2ToL2CrossDomainMessenger(predeploys.L2toL2CrossDomainMessengerAddr, sourceClient)
+	require.NoError(t, err)
+
+	// Create initiating message using L2ToL2CrossDomainMessenger
+	origin := predeploys.L2toL2CrossDomainMessengerAddr
+	parsedSchemaRegistryAbi, _ := abi.JSON(strings.NewReader(opbindings.SchemaRegistryABI))
+	data, err := parsedSchemaRegistryAbi.Pack("register", "uint256 value", common.HexToAddress("0x0000000000000000000000000000000000000000"), false)
+	require.NoError(t, err)
+
+	sourceTransactor, err := bind.NewKeyedTransactorWithChainID(privateKey, testSuite.SourceChainID)
+	require.NoError(t, err)
+	tx, err := l2ToL2CrossDomainMessenger.SendMessage(sourceTransactor, testSuite.DestChainID, predeploys.SchemaRegistryAddr, data)
+	require.NoError(t, err)
+
+	initiatingMessageTxReceipt, err := bind.WaitMined(context.Background(), sourceClient, tx)
+	require.NoError(t, err)
+	require.True(t, initiatingMessageTxReceipt.Status == 1, "initiating message transaction failed")
+
+	// progress forward one block before sending tx
+	err = destClient.Client().CallContext(context.Background(), nil, "anvil_mine", uint64(3), uint64(2))
+	require.NoError(t, err)
+	err = sourceClient.Client().CallContext(context.Background(), nil, "anvil_mine", uint64(3), uint64(2))
+	require.NoError(t, err)
+
+	crossL2Inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, destClient)
+	require.NoError(t, err)
+	initiatingMessageBlockHeader, err := sourceClient.HeaderByNumber(context.Background(), initiatingMessageTxReceipt.BlockNumber)
 	require.NoError(t, err)
 
 	initiatingMessageLog := initiatingMessageTxReceipt.Logs[0]
@@ -1067,4 +1246,63 @@ func TestAdminGetL2ToL2MessageByMsgHash(t *testing.T) {
 	assert.Equal(t, testSuite.SourceChainID.Uint64(), message.Source)
 	assert.Equal(t, tx.To().String(), message.Target.String())
 	assert.Equal(t, tx.To().String(), message.Sender.String())
+}
+
+func TestEthSubscribeNewHeads(t *testing.T) {
+	t.Parallel()
+	testSuite := createTestSuite(t)
+
+	// Connect to the WebSocket endpoint
+	wsURL := strings.Replace(testSuite.Supersim.Orchestrator.Endpoint(testSuite.Supersim.NetworkConfig.L2Configs[0].ChainID), "http", "ws", 1)
+	fmt.Println("wsURL", wsURL)
+	conn, err := websocket.Dial(wsURL, "", "http://localhost")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Subscribe to newHeads
+	subscribeMsg := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "eth_subscribe",
+		"params":  []string{"newHeads"},
+	}
+	err = websocket.JSON.Send(conn, subscribeMsg)
+	require.NoError(t, err)
+
+	// Read the subscription response
+	var subscribeResponse map[string]interface{}
+	err = websocket.JSON.Receive(conn, &subscribeResponse)
+	require.NoError(t, err)
+	require.NotNil(t, subscribeResponse["result"])
+	subscriptionID := subscribeResponse["result"].(string)
+	require.NotEmpty(t, subscriptionID)
+
+	// Mine a new block to trigger the subscription
+	err = testSuite.Supersim.Orchestrator.L2Chains()[0].EthClient().Client().CallContext(context.Background(), nil, "anvil_mine", uint64(1))
+	require.NoError(t, err)
+
+	// Read the notification
+	var notification map[string]interface{}
+	err = websocket.JSON.Receive(conn, &notification)
+	require.NoError(t, err)
+	require.Equal(t, "eth_subscription", notification["method"])
+	require.Equal(t, subscriptionID, notification["params"].(map[string]interface{})["subscription"])
+	require.NotNil(t, notification["params"].(map[string]interface{})["result"])
+
+	// Unsubscribe
+	unsubscribeMsg := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "eth_unsubscribe",
+		"params":  []string{subscriptionID},
+	}
+	err = websocket.JSON.Send(conn, unsubscribeMsg)
+	require.NoError(t, err)
+
+	// Read the unsubscribe response
+	var unsubscribeResponse map[string]interface{}
+	err = websocket.JSON.Receive(conn, &unsubscribeResponse)
+	require.NoError(t, err)
+	fmt.Println("unsubscribeResponse", unsubscribeResponse)
+	require.True(t, unsubscribeResponse["result"].(bool))
 }

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -1303,6 +1303,5 @@ func TestEthSubscribeNewHeads(t *testing.T) {
 	var unsubscribeResponse map[string]interface{}
 	err = websocket.JSON.Receive(conn, &unsubscribeResponse)
 	require.NoError(t, err)
-	fmt.Println("unsubscribeResponse", unsubscribeResponse)
 	require.True(t, unsubscribeResponse["result"].(bool))
 }

--- a/supersim_test.go
+++ b/supersim_test.go
@@ -2,7 +2,6 @@ package supersim
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"strings"
 	"sync"
@@ -1253,9 +1252,7 @@ func TestEthSubscribeNewHeads(t *testing.T) {
 	testSuite := createTestSuite(t)
 
 	// Connect to the WebSocket endpoint
-	wsURL := strings.Replace(testSuite.Supersim.Orchestrator.Endpoint(testSuite.Supersim.NetworkConfig.L2Configs[0].ChainID), "http", "ws", 1)
-	fmt.Println("wsURL", wsURL)
-	conn, err := websocket.Dial(wsURL, "", "http://localhost")
+	conn, err := websocket.Dial(testSuite.Supersim.Orchestrator.WSEndpoint(testSuite.Supersim.NetworkConfig.L2Configs[0].ChainID), "", "http://localhost")
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"context"
 	"math/big"
+	"net/rpc"
 
 	"github.com/ethereum-optimism/supersim/config"
 
@@ -61,6 +62,10 @@ func (c *MockChain) Stop(_ context.Context) error {
 }
 
 func (c *MockChain) EthClient() *ethclient.Client {
+	return nil
+}
+
+func (c *MockChain) RpcClient() *rpc.Client {
 	return nil
 }
 

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"context"
 	"math/big"
-	"net/rpc"
 
 	"github.com/ethereum-optimism/supersim/config"
 
@@ -62,10 +61,6 @@ func (c *MockChain) Stop(_ context.Context) error {
 }
 
 func (c *MockChain) EthClient() *ethclient.Client {
-	return nil
-}
-
-func (c *MockChain) RpcClient() *rpc.Client {
 	return nil
 }
 

--- a/testutils/mockchain.go
+++ b/testutils/mockchain.go
@@ -32,6 +32,10 @@ func (c *MockChain) Endpoint() string {
 	return "http://localhost:8545"
 }
 
+func (c *MockChain) WSEndpoint() string {
+	return "ws://localhost:8545"
+}
+
 func (c *MockChain) LogPath() string {
 	return "var/chain/log"
 }


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/supersim/issues/374

Another approach to websocket support. This involves propagating the websocket connection to the underlying anvil instance for eth subscription requests.